### PR TITLE
avoid using back ticks in jar manifest

### DIFF
--- a/jr-objects/pom.xml
+++ b/jr-objects/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <artifactId>jackson-jr-objects</artifactId>
   <packaging>bundle</packaging>
-  <description>Simple data-binding that builds directly on `jackson-core` (streaming),
+  <description>Simple data-binding that builds directly on jackson-core (streaming),
 has no other dependencies, and provides additional builder-style content generator
 </description>
   <url>http://wiki.fasterxml.com/JacksonHome</url>

--- a/jr-stree/pom.xml
+++ b/jr-stree/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <artifactId>jackson-jr-stree</artifactId>
   <packaging>bundle</packaging>
-  <description>Simple immutable (read-only) tree model that builds directly on `jackson-core` (streaming),
+  <description>Simple immutable (read-only) tree model that builds directly on jackson-core (streaming),
 has no other dependencies.
 </description>
   <url>https://github.com/FasterXML/jackson-jr</url>


### PR DESCRIPTION
Current versions of jdk9 have a bug in the JarFile.match
function which throws an ArrayIndexOutOfBoundsException
if a back tick is encountered. This change works around
the issue by removing the back ticks from the build
description. See #55 for test case.