### PR TITLE
Add options for case insensitive properties and enum values.

### DIFF
--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/JSON.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/JSON.java
@@ -281,7 +281,30 @@ public class JSON implements Versioned
          * @since 2.13
          */
         INCLUDE_STATIC_FIELDS(false, true),
-        ;
+
+        /**
+         * Feature that will allow for more forgiving deserialization of incoming JSON. If enabled,
+         * the bean properties will be matched using their lower-case equivalents, meaning that any
+         * case-combination (incoming and matching names are canonicalized by lower-casing) should work.
+         * <p>
+         * Note that there is additional performance overhead since incoming property names need to be lower-cased
+         * before comparison, for cases where there are upper-case letters. Overhead for names that are already
+         * lower-case should be negligible however.
+         *<p>
+         * Feature is <b>disabled</b> by default.
+         */
+        ACCEPT_CASE_INSENSITIVE_PROPERTIES(false, true),
+
+        /**
+         * Feature that determines if Enum deserialization should be case sensitive or not. If enabled,
+         * Enum deserialization will ignore case, that is, case of incoming String value and enum id
+         * (dependant on other settings, either `name()`, `toString()`, or explicit override) do not need to
+         * match.
+         *<p>
+         * Feature is <b>disabled</b> by default.
+         */
+        ACCEPT_CASE_INSENSITIVE_ENUMS(false, true)
+       ;
 
         /*
         /**********************************************************************

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueReaderLocator.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueReaderLocator.java
@@ -301,7 +301,9 @@ public class ValueReaderLocator
         if (_readerModifier != null) {
             def = _readerModifier.pojoDefinitionForDeserialization(_readContext, enumType);
         }
-        Map<String, Object> byName = new HashMap<String, Object>();
+        Map<String, Object> byName =
+                JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS.isEnabled(_features) ? new TreeMap<String, Object>(
+                        String.CASE_INSENSITIVE_ORDER) : new HashMap<String, Object>();
         Object[] enums = enumType.getEnumConstants();
         if (def == null) {
             for (Object e : enums) {
@@ -460,7 +462,8 @@ public class ValueReaderLocator
         if (len == 0) {
             propMap = Collections.emptyMap();
         } else {
-            propMap = new HashMap<String, BeanPropertyReader>();
+            propMap = JSON.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES.isEnabled(_features) ? new TreeMap<String,
+                BeanPropertyReader>(String.CASE_INSENSITIVE_ORDER) : new HashMap<String, BeanPropertyReader>();
             final boolean useFields = JSON.Feature.USE_FIELDS.isEnabled(_features);
             for (int i = 0; i < len; ++i) {
                 POJODefinition.Prop rawProp = rawProps.get(i);
@@ -495,7 +498,8 @@ public class ValueReaderLocator
                 //   we must link via name of primary property, unfortunately:
                 if (rawProp.hasAliases()) {
                     if (aliasMapping == null) {
-                        aliasMapping = new HashMap<String, String>();
+                        aliasMapping = JSON.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES.isEnabled(_features) ? new TreeMap<String,
+                                String>(String.CASE_INSENSITIVE_ORDER) : new HashMap<String, String>();
                     }
                     for (String alias : rawProp.aliases()) {
                         aliasMapping.put(alias, rawProp.name);

--- a/jr-objects/src/test/java/com/fasterxml/jackson/jr/ob/ReadBeansTest.java
+++ b/jr-objects/src/test/java/com/fasterxml/jackson/jr/ob/ReadBeansTest.java
@@ -9,24 +9,36 @@ public class ReadBeansTest extends TestBase
     static class TestBean {
         protected int x;
         protected NameBean name;
-        
+        protected Option option;
+
+        public void setOption(Option o) {
+            option = o;
+        }
         public void setName(NameBean n) { name = n; }
         public void setX(int x) { this.x = x; }
 
+        public Option getOption() {
+            return option;
+        }
         public int getX() { return x; }
         public NameBean getName() { return name; }
     }
 
+    private enum Option {
+        Option1,
+        Option2
+    }
+
     static class MapBean {
         protected Map<String,Integer> stuff;
-        
+
         public Map<String,Integer> getStuff() { return stuff; }
         public void setStuff(Map<String,Integer> s) { stuff = s; }
     }
 
     static class NameListBean {
         protected List<NameBean> names;
-        
+
         public List<NameBean> getNames() { return names; }
         public void setNames(List<NameBean> n) { names = n; }
     }
@@ -34,7 +46,7 @@ public class ReadBeansTest extends TestBase
     interface Bean<T> {
         public void setValue(T t);
     }
-    
+
     static class LongBean implements Bean<Long> {
         Long value;
 
@@ -47,7 +59,7 @@ public class ReadBeansTest extends TestBase
     static class URLBean {
         String url;
 
-        public void setURL(String s) { url = s; } 
+        public void setURL(String s) { url = s; }
     }
 
     /*
@@ -58,7 +70,7 @@ public class ReadBeansTest extends TestBase
 
     public void testSimpleBean() throws Exception
     {
-        final String INPUT = aposToQuotes("{'name':{'first':'Bob','last':'Burger'},'x':13}");
+        final String INPUT = aposToQuotes("{'name':{'first':'Bob','last':'Burger'},'x':13, 'option': 'Option1'}");
         TestBean bean = JSON.std.beanFrom(TestBean.class, INPUT);
 
         assertNotNull(bean);
@@ -66,6 +78,25 @@ public class ReadBeansTest extends TestBase
         assertNotNull(bean.name);
         assertEquals("Bob", bean.name.first);
         assertEquals("Burger", bean.name.last);
+        assertEquals(Option.Option1, bean.option);
+    }
+
+    public void testSimpleBeanCaseInsensitive() throws Exception
+    {
+        final String INPUT = aposToQuotes("{'NaMe':{'FIRST':'Bob','last':'Burger'},'x':13, 'optioN': 'opTIOn1'}");
+        TestBean bean =
+                JSON.builder()
+                        .enable(JSON.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+                        .enable(JSON.Feature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                        .build()
+                        .beanFrom(TestBean.class, INPUT);
+
+        assertNotNull(bean);
+        assertEquals(13, bean.x);
+        assertNotNull(bean.name);
+        assertEquals("Bob", bean.name.first);
+        assertEquals("Burger", bean.name.last);
+        assertEquals(Option.Option1, bean.option);
     }
 
     public void testUnknownProps() throws Exception
@@ -103,7 +134,7 @@ public class ReadBeansTest extends TestBase
         NameBean name = list.names.get(1);
         assertEquals("Burger", name.getLast());
     }
-    
+
     public void testPOJOWithMap() throws Exception
     {
         final String INPUT = aposToQuotes("{'stuff': { 'a':3, 'b':4 } }");
@@ -173,7 +204,7 @@ public class ReadBeansTest extends TestBase
         assertEquals("Billy", bean2.name.first);
         assertEquals("Bacon", bean2.name.last);
     }
-    
+
     public void testJvmSerializersPOJO() throws Exception
     {
         MediaItem.Content content = new MediaItem.Content();


### PR DESCRIPTION
Adds options for case insensitive bean properties and enum values.
This change will close #80.

Added new tests to verify this functionality which are passing. All existing tests are passing.

As this is my first PR on this code base please forgive any issues and let me know what needs to be done to address them. I'm more than happy to work with you to get this in. Our team is trying to migrate to jackson-jr from databind to reduce our memory requirements and we've seen a large impact already.