### PR TITLE
Implement equals for Jrs types

### DIFF
--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsArray.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsArray.java
@@ -83,7 +83,7 @@ public class JrsArray extends JrsValue
             return _values.iterator();
         }
         // ensure caller can not modify values this way
-        return Collections.unmodifiableList(_values).iterator();            
+        return Collections.unmodifiableList(_values).iterator();
     }
 
     /*
@@ -100,5 +100,24 @@ public class JrsArray extends JrsValue
             codec.writeTree(g, _values.get(i));
         }
         g.writeEndArray();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsArray jrsArray = (JrsArray) o;
+
+        return _values != null ? _values.equals(jrsArray._values) : jrsArray._values == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return _values != null ? _values.hashCode() : 0;
     }
 }

--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsBoolean.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsBoolean.java
@@ -48,4 +48,23 @@ public class JrsBoolean extends JrsValue.Scalar
     protected void write(JsonGenerator g, JacksonJrsTreeCodec codec) throws IOException {
         g.writeBoolean(_value);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsBoolean that = (JrsBoolean) o;
+
+        return _value == that._value;
+    }
+
+    @Override
+    public int hashCode() {
+        return (_value ? 1 : 0);
+    }
 }

--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsEmbeddedObject.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsEmbeddedObject.java
@@ -59,4 +59,23 @@ public class JrsEmbeddedObject extends JrsValue.Scalar
             g.writeObject(_value);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsEmbeddedObject that = (JrsEmbeddedObject) o;
+
+        return _value != null ? _value.equals(that._value) : that._value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return _value != null ? _value.hashCode() : 0;
+    }
 }

--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsNumber.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsNumber.java
@@ -71,7 +71,7 @@ public class JrsNumber extends JrsValue.Scalar
     public String asText() {
         return String.valueOf(_value);
     }
-    
+
     @Override
     public JsonParser.NumberType numberType() {
         return _numberType;
@@ -82,7 +82,7 @@ public class JrsNumber extends JrsValue.Scalar
     /* Extended API
     /**********************************************************************
      */
-    
+
     public BigInteger asBigInteger() throws IOException {
         if (_value instanceof BigInteger) {
             return (BigInteger) _value;
@@ -137,5 +137,29 @@ public class JrsNumber extends JrsValue.Scalar
             g.writeNumber(_value.doubleValue());
             break;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsNumber jrsNumber = (JrsNumber) o;
+
+        if (_value != null ? !_value.equals(jrsNumber._value) : jrsNumber._value != null) {
+            return false;
+        }
+        return _numberType == jrsNumber._numberType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = _value != null ? _value.hashCode() : 0;
+        result = 31 * result + (_numberType != null ? _numberType.hashCode() : 0);
+        return result;
     }
 }

--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsObject.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsObject.java
@@ -56,7 +56,7 @@ public class JrsObject extends JrsValue
     public JrsValue get(int i) {
         return null;
     }
-    
+
     @Override
     public JrsValue get(String name) {
         return _values.get(name);
@@ -110,5 +110,24 @@ public class JrsObject extends JrsValue
             }
         }
         g.writeEndObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsObject jrsObject = (JrsObject) o;
+
+        return _values != null ? _values.equals(jrsObject._values) : jrsObject._values == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return _values != null ? _values.hashCode() : 0;
     }
 }

--- a/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsString.java
+++ b/jr-stree/src/main/java/com/fasterxml/jackson/jr/stree/JrsString.java
@@ -42,4 +42,23 @@ public class JrsString extends JrsValue.Scalar
     protected void write(JsonGenerator g, JacksonJrsTreeCodec codec) throws IOException {
         g.writeString(_value);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JrsString jrsString = (JrsString) o;
+
+        return _value.equals(jrsString._value);
+    }
+
+    @Override
+    public int hashCode() {
+        return _value.hashCode();
+    }
 }


### PR DESCRIPTION
Implementing equals and hashCode for all the Jrs* types which were missing it. I simply used IntelliJ's automatic generator to make the code.