### PR TITLE
Add option for serializing and deserializing non-final static fields, disabled by default

### DIFF
--- a/jr-annotation-support/src/main/java/com/fasterxml/jackson/jr/annotationsupport/AnnotationBasedIntrospector.java
+++ b/jr-annotation-support/src/main/java/com/fasterxml/jackson/jr/annotationsupport/AnnotationBasedIntrospector.java
@@ -31,20 +31,22 @@ public class AnnotationBasedIntrospector
      * Visibility settings to use for auto-detecting accessors.
      */
     protected final JsonAutoDetect.Value _visibility;
-    
+
     // // // State (collected properties, related)
-    
+
     protected final Map<String, APropBuilder> _props = new HashMap<String, APropBuilder>();
 
     // // // State only for deserialization:
 
     protected Set<String> _ignorableNames;
+    protected int _features;
 
     protected AnnotationBasedIntrospector(Class<?> type, boolean serialization,
-            JsonAutoDetect.Value visibility) {
+                                          JsonAutoDetect.Value visibility, int features) {
         _type = type;
         _forSerialization = serialization;
         _ignorableNames = serialization ? null : new HashSet<String>();
+        _features = features;
 
         // First things first: find possible `@JsonAutoDetect` to override
         // default visibility settings
@@ -58,13 +60,13 @@ public class AnnotationBasedIntrospector
 
     public static POJODefinition pojoDefinitionForDeserialization(JSONReader r,
             Class<?> pojoType, JsonAutoDetect.Value visibility) {
-        return new AnnotationBasedIntrospector(pojoType, false, visibility)
+        return new AnnotationBasedIntrospector(pojoType, false, visibility, r.features())
                 .introspectDefinition();
     }
 
     public static POJODefinition pojoDefinitionForSerialization(JSONWriter w,
             Class<?> pojoType, JsonAutoDetect.Value visibility) {
-        return new AnnotationBasedIntrospector(pojoType, true, visibility)
+        return new AnnotationBasedIntrospector(pojoType, true, visibility, w.features())
                 .introspectDefinition();
     }
 
@@ -235,9 +237,9 @@ public class AnnotationBasedIntrospector
 
         // then get fields from within class itself
         for (Field f : currType.getDeclaredFields()) {
-            // Does not include static fields, but there are couple of things we do
-            // not include regardless:
-            if (f.isEnumConstant() || f.isSynthetic()) {
+            // skip static fields and synthetic fields except for enum constants
+            if ((JSON.Feature.INCLUDE_STATIC_FIELDS.isDisabled(_features) && Modifier.isStatic(f.getModifiers())
+                    && !f.isEnumConstant()) || f.isSynthetic()) {
                 continue;
             }
             // otherwise, first things first; explicit ignoral?
@@ -284,7 +286,7 @@ public class AnnotationBasedIntrospector
             final int flags = m.getModifiers();
             // 13-Jun-2015, tatu: Skip synthetic, bridge methods altogether, for now
             //    at least (add more complex handling only if absolutely necessary)
-            if (Modifier.isStatic(flags)
+            if ((JSON.Feature.INCLUDE_STATIC_FIELDS.isDisabled(_features) && Modifier.isStatic(flags))
                     || m.isSynthetic() || m.isBridge()) {
                 continue;
             }
@@ -350,7 +352,7 @@ public class AnnotationBasedIntrospector
                     acc = APropAccessor.createVisible(implName, m);
                 } else {
                     acc = APropAccessor.createExplicit(explName, m);
-                }                    
+                }
             }
         }
         _propBuilder(implName).getter = acc;
@@ -397,7 +399,7 @@ public class AnnotationBasedIntrospector
                     acc = APropAccessor.createVisible(implName, m);
                 } else {
                     acc = APropAccessor.createExplicit(explName, m);
-                }                    
+                }
             }
         }
         _propBuilder(implName).setter = acc;
@@ -410,9 +412,10 @@ public class AnnotationBasedIntrospector
      */
 
     protected boolean _isFieldVisible(Field f) {
-        // Consider transient to be non-visible
+        // Consider transient and static-final to be non-visible
         // TODO: (maybe?) final
-        return !Modifier.isTransient(f.getModifiers())
+        return !(Modifier.isFinal(f.getModifiers()) && Modifier.isStatic(f.getModifiers()))
+                && !Modifier.isTransient(f.getModifiers())
                 && _visibility.getFieldVisibility().isVisible(f);
     }
 
@@ -426,7 +429,7 @@ public class AnnotationBasedIntrospector
     protected boolean _isSetterVisible(Method m) {
         return _visibility.getSetterVisibility().isVisible(m);
     }
-    
+
     /*
     /**********************************************************************
     /* Internal methods, annotation introspection
@@ -449,7 +452,7 @@ public class AnnotationBasedIntrospector
      * Lookup method for finding possible annotated order of property names
      * for the type this introspector is to introspect
      *
-     * @return List of property names that defines order (possibly partial); if 
+     * @return List of property names that defines order (possibly partial); if
      *   none, empty List (but never null)
      */
     protected List<String> _findNameSortOrder() {
@@ -465,7 +468,7 @@ public class AnnotationBasedIntrospector
      * for the type this introspector is to introspect that should be ignored
      * (both for serialization and deserialization).
      *
-     * @return List of property names that defines order (possibly partial); if 
+     * @return List of property names that defines order (possibly partial); if
      *   none, empty List (but never null)
      */
     protected Collection<String> _findIgnorableNames() {
@@ -480,13 +483,13 @@ public class AnnotationBasedIntrospector
     protected <ANN extends Annotation> ANN _find(AnnotatedElement elem, Class<ANN> annotationType) {
         return elem.getAnnotation(annotationType);
     }
-    
+
     /*
     /**********************************************************************
     /* Internal methods, other
     /**********************************************************************
      */
-    
+
     protected APropBuilder _propBuilder(String name) {
         APropBuilder b = _props.get(name);
         if (b == null) {
@@ -546,7 +549,7 @@ public class AnnotationBasedIntrospector
     /* Helper classes
     /**********************************************************************
      */
-    
+
     protected static class APropBuilder
         implements Comparable<APropBuilder>
     {
@@ -615,7 +618,7 @@ public class AnnotationBasedIntrospector
             // should be fine to take first one
             return a1;
         }
-        
+
         public APropBuilder withName(String newName) {
             APropBuilder newB = new APropBuilder(this, newName);
             newB.field = field;
@@ -676,7 +679,7 @@ public class AnnotationBasedIntrospector
             }
             return collectedAliases;
         }
-        
+
         private String _firstExplicit(APropAccessor<?> acc1,
                 APropAccessor<?> acc2,
                 APropAccessor<?> acc3) {

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/JSON.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/JSON.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.jr.ob.impl.*;
  * <li>{@link URL}</li>
  * <li>{@link File}</li>
  * </ul>
- * 
+ *
  */
 @SuppressWarnings("resource")
 public class JSON implements Versioned
@@ -167,7 +167,7 @@ public class JSON implements Versioned
         * @since 2.7
         */
        WRITE_DATES_AS_TIMESTAMP(false),
-       
+
        /**
         * Feature that can be enabled to use "pretty-printing", basic indentation
         * to make resulting JSON easier to read by humans by adding white space
@@ -241,7 +241,7 @@ public class JSON implements Versioned
         * so that all Bean properties are serialized.
         */
        WRITE_READONLY_BEAN_PROPERTIES(true, true),
-       
+
        /**
         * Feature that determines whether access to {@link java.lang.reflect.Method}s and
         * {@link java.lang.reflect.Constructor}s that are used with dynamically
@@ -260,7 +260,7 @@ public class JSON implements Versioned
         * @since 2.5
         */
        USE_IS_GETTERS(true, true),
-       
+
        /**
         * Feature that enables use of public fields instead of setters and getters,
         * in cases where no setter/getter is available.
@@ -271,6 +271,16 @@ public class JSON implements Versioned
         * @since 2.8 (enabled by default since 2.10)
         */
        USE_FIELDS(true, true),
+
+        /**
+         * Feature that enables serialization and deserialization of non-final static fields.
+         *<p>
+         * Feature did not exist, but was implicitly <b>enabled</b> by default. <b>disabled</b> for
+         * 2.13).
+         *
+         * @since 2.13
+         */
+        INCLUDE_STATIC_FIELDS(false, true),
        ;
 
        /*
@@ -422,7 +432,7 @@ public class JSON implements Versioned
         protected PrettyPrinter _prettyPrinter;
 
         // Configuration, helper objects
-        
+
         protected final JsonFactory _streamFactory;
         protected TreeCodec _treeCodec;
 
@@ -502,7 +512,7 @@ public class JSON implements Versioned
         }
 
         // // // Mutators, helper objects
-        
+
         /**
          * Method for specifying {@link PrettyPrinter} {@link JSON} to be built
          * should use on serialization.
@@ -732,7 +742,7 @@ public class JSON implements Versioned
     public ObjectCodec asCodec() {
         return new JSONAsObjectCodec(this);
     }
-    
+
     /*
     /**********************************************************************
     /* Versioned
@@ -785,7 +795,7 @@ public class JSON implements Versioned
         }
         return _with(f);
     }
-    
+
     /**
      * Mutant factory for constructing an instance with specified features
      * enabled.
@@ -825,7 +835,7 @@ public class JSON implements Versioned
         //    changes
         JSONReader r = _reader.withCacheCheck(features);
         JSONWriter w = _writer.withCacheCheck(features);
-        
+
         return _with(features, _jsonFactory, _treeCodec,
                 r, w, _prettyPrinter);
     }
@@ -839,14 +849,14 @@ public class JSON implements Versioned
     /**
      * Mutant factory method for constructing new instance with specified {@link JsonFactory}
      * if different from currently configured one (if not, return {@code this} as-is)
-     * 
+     *
      * @param f Jackson core format factory to use for low-level decoding/encoding
      *
      * @return New instance with specified factory (if not same as currently configured);
      *   {@code this} otherwise.
      *
      * @deprecated Since 2.11 should not try changing underlying stream factory but create
-     *   a new instance if necessary: method will be removed from 3.0 at latest 
+     *   a new instance if necessary: method will be removed from 3.0 at latest
      */
     @Deprecated
     public JSON with(JsonFactory f) {
@@ -966,7 +976,7 @@ public class JSON implements Versioned
     /* Methods sub-classes must override
     /**********************************************************************
      */
-    
+
     protected JSON _with(int features,
             JsonFactory jsonF, TreeCodec trees,
             JSONReader reader, JSONWriter writer,
@@ -992,7 +1002,7 @@ public class JSON implements Versioned
     public final boolean isEnabled(Feature f) {
         return (f.mask() & _features) != 0;
     }
-    
+
     /*
     /**********************************************************************
     /* Public factory methods for parsers, generators
@@ -1122,7 +1132,7 @@ public class JSON implements Versioned
     public <C extends Collection<Object>> CollectionComposer<?,C> composeCollection(C collection) {
         return new CollectionComposer<ComposerBase,C>(collection);
     }
-    
+
     public MapComposer<?> composeMap() {
         return composeMap(new LinkedHashMap<String,Object>());
     }
@@ -1294,7 +1304,7 @@ public class JSON implements Versioned
             return _closeWithError(p, e);
         }
     }
-    
+
     /**
      * Read method that will take given JSON Source (of one of supported types),
      * read contents and map it to one of simple mappings ({@link java.util.Map}
@@ -1476,7 +1486,7 @@ public class JSON implements Versioned
           }
          return (T) _treeCodec.createArrayNode();
     }
-    
+
     /**
      * Convenience method, equivalent to:
      *<pre>
@@ -1527,7 +1537,7 @@ public class JSON implements Versioned
     /* Internal methods, reading
     /**********************************************************************
      */
-    
+
     protected JSONReader _readerForOperation(JsonParser p) {
         return _reader.perOperationInstance(_features, _valueReaderLocator, _treeCodec, p);
     }
@@ -1585,7 +1595,7 @@ public class JSON implements Versioned
     /* Internal methods, other
     /**********************************************************************
      */
-    
+
     protected JsonGenerator _config(JsonGenerator g)
     {
         // First, possible pretty printing
@@ -1629,7 +1639,7 @@ public class JSON implements Versioned
         }
         throw new IOException(e); // should never occur
     }
-    
+
     protected void _noTreeCodec(String msg) {
          throw new IllegalStateException("JSON instance does not have configured `TreeCodec` to "+msg);
     }
@@ -1641,7 +1651,7 @@ public class JSON implements Versioned
      */
 
     /**
-     * Extension context implementation used when 
+     * Extension context implementation used when
      */
     private static class ExtContextImpl extends ExtensionContext {
         final Builder _builder;

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/JSONReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/JSONReader.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.jr.ob.api.ValueReader;
  * any of reading itself (despite name).
  *<p>
  * Life-cycle is such that initial instance (called blueprint)
- * is constructed first (including possible configuration 
+ * is constructed first (including possible configuration
  * using mutant factory methods). This blueprint object
  * acts as a factory, and is never used for direct reading;
  * instead, per-call instance is created by calling
@@ -177,6 +177,13 @@ public class JSONReader
         return f.isEnabled(_features);
     }
 
+    /**
+     * @since 2.13
+     */
+    public int features() {
+        return _features;
+    }
+
     /*
     /**********************************************************************
     /* Public entry points for reading Simple objects from JSON
@@ -226,7 +233,7 @@ public class JSONReader
         }
         return (List<Object>) AnyReader.std.readCollectionFromArray(this, _parser, _collectionBuilder);
     }
-    
+
     /**
      * Method for reading a JSON Array from input and building a <code>Object[]</code>
      * out of it. Note that if input does NOT contain a

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/JSONWriter.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/JSONWriter.java
@@ -20,7 +20,7 @@ import static com.fasterxml.jackson.jr.ob.impl.ValueWriterLocator.*;
  * and uses delegation for only some special cases.
  *<p>
  * Life-cycle is such that initial instance (called blueprint)
- * is constructed first (including possible configuration 
+ * is constructed first (including possible configuration
  * using mutant factory methods). This blueprint object
  * acts as a factory, and is never used for direct writing;
  * instead, per-call instance is created by calling
@@ -56,7 +56,7 @@ public class JSONWriter
     protected final int _features;
 
     protected final boolean _writeNullValues;
-    
+
     /*
     /**********************************************************************
     /* Blueprint construction
@@ -137,6 +137,13 @@ public class JSONWriter
      */
     public boolean isEnabled(JSON.Feature f) {
         return f.isEnabled(_features);
+    }
+
+    /**
+     * @since 2.13
+     */
+    public int features() {
+        return _features;
     }
 
     /*
@@ -252,7 +259,7 @@ public class JSONWriter
             return;
 
         // Others
-            
+
         case SER_ITERABLE:
             writeIterableField(fieldName, (Iterable<?>) value);
             return;
@@ -318,7 +325,7 @@ public class JSONWriter
             return;
 
         // Number types:
-            
+
         case SER_NUMBER_FLOAT: // fall through
         case SER_NUMBER_DOUBLE:
             writeDoubleValue(((Number) value).doubleValue());
@@ -392,7 +399,7 @@ public class JSONWriter
     /* Overridable concrete typed write methods, structured types
     /**********************************************************************
      */
-    
+
     protected void writeCollectionValue(Collection<?> v) throws IOException
     {
         _generator.writeStartArray();
@@ -407,7 +414,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeCollectionValue(v);
     }
-    
+
     protected void writeIterableValue(Iterable<?> v) throws IOException
     {
         _generator.writeStartArray();
@@ -422,7 +429,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeIterableValue(v);
     }
-    
+
     protected void writeListValue(List<?> list) throws IOException
     {
         _generator.writeStartArray();
@@ -442,7 +449,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeListValue(v);
     }
-    
+
     protected void writeMapValue(Map<?,?> v) throws IOException
     {
         _generator.writeStartObject();
@@ -496,7 +503,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeIntArrayValue(v);
     }
-    
+
     protected void writeLongArrayValue(long[] v) throws IOException {
         _generator.writeStartArray();
         for (int i = 0, len = v.length; i < len; ++i) {
@@ -509,7 +516,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeLongArrayValue(v);
     }
-    
+
     protected void writeBooleanArrayValue(boolean[] v) throws IOException {
         _generator.writeStartArray();
         for (int i = 0, len = v.length; i < len; ++i) {
@@ -535,7 +542,7 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeTreeNodeValue(v);
     }
-    
+
     /*
     /**********************************************************************
     /* Overridable concrete typed write methods, primitives
@@ -570,11 +577,11 @@ public class JSONWriter
         _generator.writeFieldName(fieldName);
         writeBigIntegerValue(v);
     }
-    
+
     protected void writeLongField(String fieldName, long v) throws IOException {
         _generator.writeNumberField(fieldName, v);
     }
-    
+
     protected void writeDoubleValue(double v) throws IOException {
         _generator.writeNumber(v);
     }
@@ -612,7 +619,7 @@ public class JSONWriter
     protected void writeStringLikeField(String fieldName, String v, int actualType) throws IOException {
         _generator.writeStringField(fieldName, v);
     }
-    
+
     protected void writeBinaryValue(byte[] data) throws IOException {
         _generator.writeBinary(data);
     }
@@ -750,7 +757,7 @@ public class JSONWriter
     /* Other internal methods
     /**********************************************************************
      */
-    
+
     private void _badType(int type, Object value)
     {
         if (type < 0) {


### PR DESCRIPTION
Sorry for all the PRs, but I just wanted to get all my changes up for review ASAP.

This change adds the option `INCLUDE_STATIC_FIELDS` which is disabled by default. When enabled, it will allow the serialization and deserialization of non-final static fields. I am excluding final static fields because they cannot be properly deserialized without modifying the field access. Current behavior (2.12) is that the final static field will be serialized but will fail to deserialize.

I also needed to expose the features list of the `JSONReader` and `JSONWriter` in order for the annotation plugin to have access to the features and check if something is enabled or not. I would have used a method reference like `JSONReader::isEnabled(Feature)` but that's only available for Java 8 and I of course don't want to increase the version requirement unless that's something that you want to do.