### PR TITLE
Support `@JsonValue` and `@JsonCreator` for `enum`

### DIFF
--- a/jr-annotation-support/README.md
+++ b/jr-annotation-support/README.md
@@ -59,6 +59,7 @@ Following Jackson annotations are supported either partially or completely:
 * `@JsonProperty` (partial: accessor, only for inclusion/renaming (other properties ignored)
     * In 2.13, will also support renaming of `Enum` constants
 * `@JsonPropertyOrder` (complete: class)
+* `@JsonValue`/`@JsonCreator` (partial: enum only)
 
 Support for additional properties is possible in future versions.
 
@@ -71,6 +72,56 @@ limited in some ways for all annotations:
   Methods) are applied. Jackson-databind will scan the whole inheritance hierarchy
     * In future handling of Class annotations may be improved if this seems feasible
 * No support for "mix-in" annotations
+
+### Enum Support
+
+An `enum` can be tagged with `@JsonProperty` on its values to alias them
+for serialization and deserialization:
+
+```java
+enum ABCRename {
+  // first two are aliased, the last is not
+  @JsonProperty("A1") A, 
+  @JsonProperty("B1") B, 
+  C; 
+}
+```
+
+If an `enum` contains a method annotated with `@JsonValue` that returns a `String`
+then it will be used to serialize. Similarly, if it has a `@JsonCreator`
+method that can be used to deserialize, then that will be used:
+
+```java
+enum ABCJsonValueJsonCreator
+{
+    A("A1"),
+    B("B1"),
+    C("C");
+
+    private String label;
+
+    ABCJsonValueJsonCreator(String label) {
+      this.label = label;
+    }
+
+    // will be used for serialization
+    @JsonValue
+    public String serialize() {
+        return label;
+    }
+
+    // will be used for deserialization
+    @JsonCreator
+    public static ABCJsonValueJsonCreator fromLabel(String label) {
+      for (ABCJsonValueJsonCreator value : ABCJsonValueJsonCreator.values()) {
+          if (value.label.equals(label)) {
+              return value;
+          }
+      }
+      throw new IllegalArgumentException("Unexpected label '" + label + "'");
+    }
+}
+```
 
 ### Other configuration
 

--- a/jr-annotation-support/src/main/java/com/fasterxml/jackson/jr/annotationsupport/AnnotationBasedValueRWModifier.java
+++ b/jr-annotation-support/src/main/java/com/fasterxml/jackson/jr/annotationsupport/AnnotationBasedValueRWModifier.java
@@ -2,19 +2,28 @@ package com.fasterxml.jackson.jr.annotationsupport;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonGenerator;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterModifier;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.api.ValueWriter;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
 import com.fasterxml.jackson.jr.ob.impl.POJODefinition;
 import com.fasterxml.jackson.jr.ob.impl.ValueLocatorBase;
+
+import static com.fasterxml.jackson.jr.ob.impl.Types.isEnum;
 
 public class AnnotationBasedValueRWModifier extends ReaderWriterModifier
 {
@@ -43,9 +52,27 @@ public class AnnotationBasedValueRWModifier extends ReaderWriterModifier
     @Override
     public ValueWriter overrideStandardValueWriter(JSONWriter writeContext, Class<?> type, int stdTypeId) {
         if (stdTypeId == SER_ENUM_ID) {
-            return new EnumWriter(type);
+            ValueWriter writeByJsonValue = EnumJsonValueWriter.of(type);
+            if (writeByJsonValue != null) {
+                return writeByJsonValue;
+            }
+            // the EnumWriter requires this to be the actual enum type, rather than a subclass of Enum
+            if (type.isEnum()) {
+                return new EnumWriter(type);
+            }
         }
         return null;
+    }
+
+    @Override
+    public ValueReader modifyValueReader(JSONReader readContext, Class<?> type, ValueReader defaultReader) {
+        if (type.isEnum()) {
+            ValueReader readUsingJsonCreator = EnumJsonCreatorReader.of(type);
+            if (readUsingJsonCreator != null) {
+                return readUsingJsonCreator;
+            }
+        }
+        return super.modifyValueReader(readContext, type, defaultReader);
     }
 
     private static class EnumWriter implements ValueWriter {
@@ -73,6 +100,123 @@ public class AnnotationBasedValueRWModifier extends ReaderWriterModifier
         @Override
         public Class<?> valueType() {
             return _valueType;
+        }
+    }
+
+    /**
+     * Serialize an enum using the {@link JsonValue} tagged method
+     */
+    private static class EnumJsonValueWriter implements ValueWriter {
+        private final Class<?> _valueType;
+        private final Method _jsonValueMethod;
+
+        private EnumJsonValueWriter(Class<?> _valueType, Method _jsonValueMethod) {
+            this._valueType = _valueType;
+            this._jsonValueMethod = _jsonValueMethod;
+            _jsonValueMethod.setAccessible(true);
+        }
+
+        @Override
+        public void writeValue(JSONWriter context, JsonGenerator g, Object value) throws IOException {
+            try {
+                context.writeValue(_jsonValueMethod.invoke(value));
+            } catch (Exception e) {
+                throw new JSONObjectException("Cannot call JsonValue method", e);
+            }
+        }
+
+        @Override
+        public Class<?> valueType() {
+            return _valueType;
+        }
+
+        /**
+         * Scan the methods of the enum to find a {@link JsonValue} tagged method
+         * which takes no parameters and returns a {@link String}
+         * @param type the type
+         * @return either a {@link EnumJsonValueWriter} to write this enum with, or <code>null</code> if no suitable
+         * method found
+         */
+        private static EnumJsonValueWriter of(Class<?> type) {
+            return getJsonValueFunction(type, type);
+        }
+
+        private static EnumJsonValueWriter getJsonValueFunction(Class<?> type, Class<?> inspectionType) {
+            for (Method method : inspectionType.getDeclaredMethods()) {
+                JsonValue jsonValueAnnotation = method.getDeclaredAnnotation(JsonValue.class);
+                if (!Modifier.isStatic(method.getModifiers()) &&
+                        jsonValueAnnotation != null &&
+                        method.getParameterCount() == 0 &&
+                        method.getReturnType().equals(String.class)) {
+                    // this is the @JsonValue on the lowest descendent of any hierarchy
+                    // it may be put here to disable it
+                    if (jsonValueAnnotation.value()) {
+                        return new EnumJsonValueWriter(type, method);
+                    }
+
+                    // if @JsonValue is disabled, then we deliberately stop searching for another one
+                    return null;
+                }
+            }
+
+            Class<?> superClass = inspectionType.getSuperclass();
+            if (superClass != null) {
+                EnumJsonValueWriter writer = getJsonValueFunction(type, superClass);
+                if (writer != null) {
+                    return writer;
+                }
+            }
+
+            for (Class<?> parentInterface : inspectionType.getInterfaces()) {
+                EnumJsonValueWriter writer = getJsonValueFunction(type, parentInterface);
+                if (writer != null) {
+                    return writer;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Deserialize into an enum using the {@link JsonCreator} tagged method
+     */
+    private static class EnumJsonCreatorReader extends ValueReader {
+
+        private final Method _jsonCreatorMethod;
+
+        private EnumJsonCreatorReader(Class<?> valueType, Method jsonCreatorMethod) {
+            super(valueType);
+            this._jsonCreatorMethod = jsonCreatorMethod;
+            jsonCreatorMethod.setAccessible(true);
+        }
+
+        @Override
+        public Object read(JSONReader reader, JsonParser p) throws IOException {
+            try {
+                return _jsonCreatorMethod.invoke(_valueType, p.getText());
+            } catch (Exception e) {
+                throw new JSONObjectException("Cannot call JsonCreator method", e);
+            }
+        }
+
+        /**
+         * Scan the methods of the enum type to find a static method tagged with {@link JsonCreator}
+         * which takes exactly one parameter and returns a value of the enum's type
+         * @param type the type to scan
+         * @return a new {@link EnumJsonCreatorReader} to deserialize with, or <code>null</code> if there
+         * is no {@link JsonCreator} method to use
+         */
+        private static EnumJsonCreatorReader of(Class<?> type) {
+            for (Method method : type.getDeclaredMethods()) {
+                if (Modifier.isStatic(method.getModifiers()) &&
+                        method.getDeclaredAnnotation(JsonCreator.class) != null &&
+                        method.getParameterCount() == 1 &&
+                        method.getReturnType().equals(type)) {
+                    return new EnumJsonCreatorReader(type, method);
+                }
+            }
+            return null;
         }
     }
 }

--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/ASTestBase.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/ASTestBase.java
@@ -2,17 +2,15 @@ package com.fasterxml.jackson.jr.annotationsupport;
 
 import java.util.Arrays;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.jr.ob.JSON;
 
 import junit.framework.TestCase;
 
 public abstract class ASTestBase extends TestCase
 {
-    protected enum ABC { A, B, C; }
-
-    protected enum ABCRename { @JsonProperty("A1") A, @JsonProperty("B1") B, C; }
-
     protected static class NameBean {
         protected String first, last;
 

--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicRenameTest.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicRenameTest.java
@@ -1,7 +1,9 @@
 package com.fasterxml.jackson.jr.annotationsupport;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.JSONObjectException;
 
@@ -20,6 +22,96 @@ public class BasicRenameTest extends ASTestBase
             _last = l;
         }
     }
+
+    private interface EnumIdentifier {
+        @JsonValue
+        String getId();
+    }
+
+    /**
+     * enum that uses {@link JsonProperty} to alias values
+     */
+    protected enum ABCRename { @JsonProperty("A1") A, @JsonProperty("B1") B, C; }
+
+    /**
+     * enum that uses a {@link JsonValue} method to alias its values and a {@link JsonCreator} to
+     * deserialize
+     */
+    protected enum ABCJsonValueJsonCreator
+    {
+        A("A1"),
+        B("B1"),
+        C("C");
+
+        private String label;
+
+        ABCJsonValueJsonCreator(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return "ABCJsonValueJsonCreator{" +
+                    "label='" + label + '\'' +
+                    '}';
+        }
+
+        @JsonValue
+        public String serialize() {
+            return label;
+        }
+
+        @JsonCreator
+        public static ABCJsonValueJsonCreator fromLabel(String label) {
+            for (ABCJsonValueJsonCreator value : ABCJsonValueJsonCreator.values()) {
+                if (value.label.equals(label)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected label '" + label + "'");
+        }
+    }
+
+    /**
+     * Enum values in this class are anonymous inner classes
+     */
+    protected enum SubclassingEnum implements EnumIdentifier {
+        ENUM_A {
+            @Override
+            public String getId() {
+                return "A";
+            }
+        },
+        ENUM_B {
+            @Override
+            public String getId() {
+                return "B";
+            }
+        },
+        ENUM_NO_JSON_VALUE {
+            // don't use this to make the serialized version
+            // hiding the superclass's @JsonValue
+            @JsonValue(false)
+            @Override
+            public String getId() {
+                return "NONE";
+            }
+        };
+
+
+        @JsonCreator
+        public static SubclassingEnum from(String id) {
+            if ("A".equals(id)) {
+                return ENUM_A;
+            }
+            if ("B".equals(id)) {
+                return ENUM_B;
+            }
+            return null;
+        }
+    }
+
+
 
     /*
     /**********************************************************************
@@ -95,5 +187,76 @@ public class BasicRenameTest extends ASTestBase
         String jsonC = a2q("\"C\"");
         ABCRename resultC = JSON_WITH_ANNO.beanFrom(ABCRename.class, jsonC);
         assertEquals(ABCRename.C, resultC);
+    }
+
+    public void testJsonValueCreatorEnumRenameOnSerialize() throws Exception
+    {
+        ABCJsonValueJsonCreator inputA = ABCJsonValueJsonCreator.A;
+        // default
+        assertEquals("\"ABCJsonValueJsonCreator{label='A1'}\"", JSON.std.asString(inputA));
+        // with annotations
+        assertEquals(a2q("\"A1\""), JSON_WITH_ANNO.asString(inputA));
+
+        ABCJsonValueJsonCreator inputB = ABCJsonValueJsonCreator.B;
+        // default
+        assertEquals("\"ABCJsonValueJsonCreator{label='B1'}\"", JSON.std.asString(inputB));
+        // with annotations
+        assertEquals(a2q("\"B1\""), JSON_WITH_ANNO.asString(inputB));
+
+        ABCJsonValueJsonCreator inputC = ABCJsonValueJsonCreator.C;
+        // default
+        assertEquals("\"ABCJsonValueJsonCreator{label='C'}\"", JSON.std.asString(inputC));
+        // with annotations
+        assertEquals(a2q("\"C\""), JSON_WITH_ANNO.asString(inputC));
+    }
+
+    public void testJsonValueCreatorEnumRenameOnDeserialize() throws Exception
+    {
+        String jsonA = a2q("\"A1\"");
+        ABCJsonValueJsonCreator resultA = JSON_WITH_ANNO.beanFrom(ABCJsonValueJsonCreator.class, jsonA);
+        assertEquals(ABCJsonValueJsonCreator.A, resultA);
+
+        String jsonB = a2q("\"B1\"");
+        ABCJsonValueJsonCreator resultB = JSON_WITH_ANNO.beanFrom(ABCJsonValueJsonCreator.class, jsonB);
+        assertEquals(ABCJsonValueJsonCreator.B, resultB);
+
+        String jsonC = a2q("\"C\"");
+        ABCJsonValueJsonCreator resultC = JSON_WITH_ANNO.beanFrom(ABCJsonValueJsonCreator.class, jsonC);
+        assertEquals(ABCJsonValueJsonCreator.C, resultC);
+    }
+
+    public void testJsonValueCreatorHierarchicalEnumRenameOnSerialize() throws Exception
+    {
+        SubclassingEnum inputA = SubclassingEnum.ENUM_A;
+        // default
+        assertEquals("\"ENUM_A\"", JSON.std.asString(inputA));
+        // with annotations
+        assertEquals(a2q("\"A\""), JSON_WITH_ANNO.asString(inputA));
+
+        SubclassingEnum inputB = SubclassingEnum.ENUM_B;
+        // default
+        assertEquals("\"ENUM_B\"", JSON.std.asString(inputB));
+        // with annotations
+        assertEquals(a2q("\"B\""), JSON_WITH_ANNO.asString(inputB));
+    }
+
+    public void testJsonValueCreatorHierarchicalEnumRenameOnDeserialize() throws Exception
+    {
+        String jsonA = a2q("\"A\"");
+        SubclassingEnum resultA = JSON_WITH_ANNO.beanFrom(SubclassingEnum.class, jsonA);
+        assertEquals(SubclassingEnum.ENUM_A, resultA);
+
+        String jsonB = a2q("\"B\"");
+        SubclassingEnum resultB = JSON_WITH_ANNO.beanFrom(SubclassingEnum.class, jsonB);
+        assertEquals(SubclassingEnum.ENUM_B, resultB);
+    }
+
+    public void testJsonValueHidingSubclass() throws Exception
+    {
+        SubclassingEnum input = SubclassingEnum.ENUM_NO_JSON_VALUE;
+        // default
+        assertEquals("\"ENUM_NO_JSON_VALUE\"", JSON.std.asString(input));
+        // with annotations
+        assertEquals(a2q("\"ENUM_NO_JSON_VALUE\""), JSON_WITH_ANNO.asString(input));
     }
 }

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/Types.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/Types.java
@@ -1,0 +1,25 @@
+package com.fasterxml.jackson.jr.ob.impl;
+
+/**
+ * Utilities to help with reflection and types
+ */
+public final class Types {
+    private Types() {
+        // utility class
+    }
+
+    /**
+     * Detect whether a class is an enum or a subclass of an enum - e.g. an anonymous inner class
+     * inside an enum
+     * @param type the type to inspect
+     * @return <code>true</code> if effectively an enum
+     */
+    public static boolean isEnum(Class<?> type) {
+        return type.isEnum() || isParentEnum(type);
+    }
+
+    private static boolean isParentEnum(Class<?> type) {
+        Class<?> superClass = type.getSuperclass();
+        return superClass != null && isEnum(superClass);
+    }
+}

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueLocatorBase.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueLocatorBase.java
@@ -10,6 +10,8 @@ import java.util.*;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.jr.ob.JSON;
 
+import static com.fasterxml.jackson.jr.ob.impl.Types.isEnum;
+
 // Only public for reference by `AnnotationBasedValueRWModifier`
 public abstract class ValueLocatorBase
 {
@@ -187,7 +189,7 @@ public abstract class ValueLocatorBase
         if (raw == Character.class) {
             return SER_CHAR;
         }
-        if (raw.isEnum()) {
+        if (isEnum(raw)) {
             return SER_ENUM;
         }
         if (Map.class.isAssignableFrom(raw)) {


### PR DESCRIPTION
This is a potential resolution for #91 - it's based on the snippet posted, but has been re-written to better follow the house style, and to avoid balling up the whole implementation into a single class.

It comes with tests and updates to the `README.md`