### PR TITLE
Remove bogus module dependencies to fix #98

### DIFF
--- a/jr-annotation-support/src/moditect/module-info.java
+++ b/jr-annotation-support/src/moditect/module-info.java
@@ -2,8 +2,6 @@ module com.fasterxml.jackson.jr.annotationsupport {
     requires com.fasterxml.jackson.core;
 
     requires com.fasterxml.jackson.jr.ob;
-    requires com.fasterxml.jackson.jr.ob.api;
-    requires com.fasterxml.jackson.jr.ob.impl;
 
     exports com.fasterxml.jackson.jr.annotationsupport;
 }

--- a/jr-stree/src/moditect/module-info.java
+++ b/jr-stree/src/moditect/module-info.java
@@ -2,7 +2,6 @@
 module com.fasterxml.jackson.jr.stree {
     requires transitive com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.jr.ob;
-    requires com.fasterxml.jackson.jr.ob.api;
 
     exports com.fasterxml.jackson.jr.stree;
     exports com.fasterxml.jackson.jr.stree.util;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -22,3 +22,9 @@ Jonas Konrad (yawkat@github)
 
 * Suggested #88: Make `jr-stree` dependency to `jr-objects` optional
  (2.13.0)
+
+Gerben Oolbekkink (qurben@github)
+
+* Reported #98: `module-info.java` of `jr-stree` refers to module `com.fasterxml.jackson.jr.ob.api`,
+  which is not defined
+ (2.13.5)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -11,6 +11,12 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+Not yet released:
+
+#98: `module-info.java` of `jr-stree` refers to module `com.fasterxml.jackson.jr.ob.api`,
+  which is not defined
+ (reported by Gerben O)
+
 2.13.4 (03-Sep-2022)
 2.13.3 (14-May-2022)
 2.13.2 (06-Mar-2022)


### PR DESCRIPTION
Fixes #98: invalid dependency in `module-info.java` for `jr-stree`.