### PR TITLE
Fix #48: add `java.util.Date/Calendar` Extension Support

### DIFF
--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/CalendarValueReader.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/CalendarValueReader.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Calendar;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+
+/**
+ * {@link ValueReader} for {@link java.util.Calendar}. Like {@link DateValueReader}
+ * reading is lenient: it accepts both numeric timestamps (milliseconds since the
+ * Unix epoch) and textual values parsed using the configured {@link DateFormat}.
+ *
+ * @since 2.23
+ */
+public class CalendarValueReader extends ValueReader {
+    private final DateFormat _dateFormat;
+
+    public CalendarValueReader(DateFormat dateFormat) {
+        super(Calendar.class);
+        _dateFormat = dateFormat;
+    }
+
+    @Override
+    public Object read(JSONReader reader, JsonParser p) throws IOException {
+        if (p.hasToken(JsonToken.VALUE_NULL)) {
+            return null;
+        }
+        // Always accept numeric timestamps, regardless of configured format
+        if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
+            return _fromMillis(p.getLongValue());
+        }
+        final String text = p.getValueAsString();
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        try {
+            final long millis;
+            // DateFormat is not thread-safe
+            synchronized (_dateFormat) {
+                millis = _dateFormat.parse(text).getTime();
+            }
+            return _fromMillis(millis);
+        } catch (ParseException e) {
+            throw new JSONObjectException("Failed to parse `java.util.Calendar` value '"
+                    + text + "': " + e.getMessage(), e);
+        }
+    }
+
+    private static Calendar _fromMillis(long millis) {
+        Calendar c = Calendar.getInstance();
+        c.setTimeInMillis(millis);
+        return c;
+    }
+}

--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/CalendarValueWriter.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/CalendarValueWriter.java
@@ -1,0 +1,46 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.Calendar;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.jr.ob.api.ValueWriter;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+
+/**
+ * {@link ValueWriter} for {@link java.util.Calendar}. By default (when no
+ * {@link DateFormat} is configured) values are written as numeric timestamps
+ * (milliseconds since the Unix epoch); when a format is supplied they are
+ * written as textual values.
+ *
+ * @since 2.23
+ */
+public class CalendarValueWriter implements ValueWriter {
+    private final DateFormat _dateFormat;
+
+    public CalendarValueWriter(DateFormat dateFormat) {
+        _dateFormat = dateFormat;
+    }
+
+    @Override
+    public void writeValue(JSONWriter context, JsonGenerator g, Object value) throws IOException {
+        final Calendar calendar = (Calendar) value;
+        if (_dateFormat == null) {
+            // Default: numeric timestamp
+            g.writeNumber(calendar.getTimeInMillis());
+        } else {
+            final String text;
+            // DateFormat is not thread-safe
+            synchronized (_dateFormat) {
+                text = _dateFormat.format(calendar.getTime());
+            }
+            g.writeString(text);
+        }
+    }
+
+    @Override
+    public Class<?> valueType() {
+        return Calendar.class;
+    }
+}

--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/DateValueReader.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/DateValueReader.java
@@ -1,0 +1,53 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.api.ValueReader;
+import com.fasterxml.jackson.jr.ob.impl.JSONReader;
+
+/**
+ * {@link ValueReader} for {@link java.util.Date}. Reading is lenient: it accepts
+ * both numeric timestamps (milliseconds since the Unix epoch) and textual values
+ * parsed using the configured {@link DateFormat}.
+ *
+ * @since 2.23
+ */
+public class DateValueReader extends ValueReader {
+    private final DateFormat _dateFormat;
+
+    public DateValueReader(DateFormat dateFormat) {
+        super(Date.class);
+        _dateFormat = dateFormat;
+    }
+
+    @Override
+    public Object read(JSONReader reader, JsonParser p) throws IOException {
+        if (p.hasToken(JsonToken.VALUE_NULL)) {
+            return null;
+        }
+        // Always accept numeric timestamps, regardless of configured format
+        if (p.hasToken(JsonToken.VALUE_NUMBER_INT)) {
+            return new Date(p.getLongValue());
+        }
+        final String text = p.getValueAsString();
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        try {
+            // DateFormat is not thread-safe; readers get a private clone but we
+            // still guard against reuse within a single reader instance.
+            synchronized (_dateFormat) {
+                return _dateFormat.parse(text);
+            }
+        } catch (ParseException e) {
+            throw new JSONObjectException("Failed to parse `java.util.Date` value '"
+                    + text + "': " + e.getMessage(), e);
+        }
+    }
+}

--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/DateValueWriter.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/DateValueWriter.java
@@ -1,0 +1,46 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.jr.ob.api.ValueWriter;
+import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
+
+/**
+ * {@link ValueWriter} for {@link java.util.Date}. By default (when no
+ * {@link DateFormat} is configured) values are written as numeric timestamps
+ * (milliseconds since the Unix epoch); when a format is supplied they are
+ * written as textual values.
+ *
+ * @since 2.23
+ */
+public class DateValueWriter implements ValueWriter {
+    private final DateFormat _dateFormat;
+
+    public DateValueWriter(DateFormat dateFormat) {
+        _dateFormat = dateFormat;
+    }
+
+    @Override
+    public void writeValue(JSONWriter context, JsonGenerator g, Object value) throws IOException {
+        final Date date = (Date) value;
+        if (_dateFormat == null) {
+            // Default: numeric timestamp
+            g.writeNumber(date.getTime());
+        } else {
+            final String text;
+            // DateFormat is not thread-safe
+            synchronized (_dateFormat) {
+                text = _dateFormat.format(date);
+            }
+            g.writeString(text);
+        }
+    }
+
+    @Override
+    public Class<?> valueType() {
+        return Date.class;
+    }
+}

--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/JavaTimeReaderWriterProvider.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/JavaTimeReaderWriterProvider.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.jr.extension.javatime;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -7,6 +9,9 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import com.fasterxml.jackson.jr.ob.api.ReaderWriterProvider;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
@@ -20,11 +25,26 @@ import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
  */
 public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
 {
+    /**
+     * ISO-8601 pattern used as the default for parsing textual
+     * {@link java.util.Date} values (and for writing them when textual
+     * serialization is enabled via {@link #withDateFormat}).
+     */
+    private static final String DEFAULT_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
     private ZoneId _localZoneId;
-    
+
+    /**
+     * Optional format for {@link java.util.Date} serialization. When left
+     * {@code null}, dates are written as numeric timestamps (milliseconds since
+     * the Unix epoch); reading always accepts both numeric timestamps and
+     * textual values.
+     */
+    private DateFormat _dateFormat = null;
+
     protected static final DateTimeFormatter OFFSET_FORMATTER = _createFormatter(true);
     protected static final DateTimeFormatter LOCAL_FORMATTER = _createFormatter(false);
-    
+
     public JavaTimeReaderWriterProvider() {
         withLocalTimeZone(null);
     }
@@ -40,6 +60,11 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
         if (ZonedDateTime.class.isAssignableFrom(type)) {
         	return new ZonedDateTimeValueReader(_localZoneId);
         }
+        if (Date.class.isAssignableFrom(type)) {
+            // Always supply a format so textual values can be read, even when
+            // serialization defaults to numeric timestamps.
+            return new DateValueReader(_dateFormatForReading());
+        }
         return null;
     }
 
@@ -53,6 +78,11 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
         }
         if (ZonedDateTime.class.isAssignableFrom(type)) {
             return new ZonedDateTimeValueWriter();
+        }
+        if (Date.class.isAssignableFrom(type)) {
+            // null format => numeric timestamp (default)
+            DateFormat f = (_dateFormat == null) ? null : (DateFormat) _dateFormat.clone();
+            return new DateValueWriter(f);
         }
         return null;
     }
@@ -79,7 +109,35 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
     public JavaTimeReaderWriterProvider withSystemDefaultTimeZone() {
     	return withLocalTimeZone(ZoneId.systemDefault());
     }
-    
+
+    /**
+     * Method for configuring the {@link DateFormat} used for textual
+     * serialization and deserialization of {@link java.util.Date} values.
+     *<p>
+     * When set, {@code java.util.Date} values are <i>written</i> as JSON Strings
+     * using this format (instead of the default numeric timestamp), and textual
+     * values are <i>read</i> using this same format. Numeric timestamps are
+     * always accepted on read regardless of this setting.
+     *
+     * @param df {@link DateFormat} instance, or {@code null} to restore the
+     *   default (numeric timestamp serialization)
+     * @since 2.23
+     * @return This provider instance for call chaining
+     */
+    public JavaTimeReaderWriterProvider withDateFormat(DateFormat df) {
+        _dateFormat = df;
+        return this;
+    }
+
+    private DateFormat _dateFormatForReading() {
+        if (_dateFormat != null) {
+            return (DateFormat) _dateFormat.clone();
+        }
+        SimpleDateFormat f = new SimpleDateFormat(DEFAULT_DATE_PATTERN, Locale.ROOT);
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return f;
+    }
+
     /**
      * Create a forgiving date time formatter that allows different interpretations of ISO 8601
      * strings to be parsed.

--- a/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/JavaTimeReaderWriterProvider.java
+++ b/jr-extension-javatime/src/main/java/com/fasterxml/jackson/jr/extension/javatime/JavaTimeReaderWriterProvider.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -27,18 +28,23 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
 {
     /**
      * ISO-8601 pattern used as the default for parsing textual
-     * {@link java.util.Date} values (and for writing them when textual
-     * serialization is enabled via {@link #withDateFormat}).
+     * {@link java.util.Date} / {@link java.util.Calendar} values (and for
+     * writing them when textual serialization is enabled via
+     * {@link #withDateFormat}).
+     *
+     * @since 2.23
      */
     private static final String DEFAULT_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     private ZoneId _localZoneId;
 
     /**
-     * Optional format for {@link java.util.Date} serialization. When left
-     * {@code null}, dates are written as numeric timestamps (milliseconds since
-     * the Unix epoch); reading always accepts both numeric timestamps and
-     * textual values.
+     * Optional format for {@link java.util.Date} and {@link java.util.Calendar}
+     * serialization. When left {@code null}, values are written as numeric
+     * timestamps (milliseconds since the Unix epoch); reading always accepts
+     * both numeric timestamps and textual values.
+     *
+     * @since 2.23
      */
     private DateFormat _dateFormat = null;
 
@@ -65,6 +71,9 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
             // serialization defaults to numeric timestamps.
             return new DateValueReader(_dateFormatForReading());
         }
+        if (Calendar.class.isAssignableFrom(type)) {
+            return new CalendarValueReader(_dateFormatForReading());
+        }
         return null;
     }
 
@@ -81,8 +90,10 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
         }
         if (Date.class.isAssignableFrom(type)) {
             // null format => numeric timestamp (default)
-            DateFormat f = (_dateFormat == null) ? null : (DateFormat) _dateFormat.clone();
-            return new DateValueWriter(f);
+            return new DateValueWriter(_dateFormatForWriting());
+        }
+        if (Calendar.class.isAssignableFrom(type)) {
+            return new CalendarValueWriter(_dateFormatForWriting());
         }
         return null;
     }
@@ -112,12 +123,13 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
 
     /**
      * Method for configuring the {@link DateFormat} used for textual
-     * serialization and deserialization of {@link java.util.Date} values.
+     * serialization and deserialization of {@link java.util.Date} and
+     * {@link java.util.Calendar} values.
      *<p>
-     * When set, {@code java.util.Date} values are <i>written</i> as JSON Strings
-     * using this format (instead of the default numeric timestamp), and textual
-     * values are <i>read</i> using this same format. Numeric timestamps are
-     * always accepted on read regardless of this setting.
+     * When set, those values are <i>written</i> as JSON Strings using this
+     * format (instead of the default numeric timestamp), and textual values are
+     * <i>read</i> using this same format. Numeric timestamps are always accepted
+     * on read regardless of this setting.
      *
      * @param df {@link DateFormat} instance, or {@code null} to restore the
      *   default (numeric timestamp serialization)
@@ -129,6 +141,19 @@ public class JavaTimeReaderWriterProvider extends ReaderWriterProvider
         return this;
     }
 
+    /**
+     * @return Private clone of the configured format, or {@code null} when none
+     *   is configured (meaning: write numeric timestamps).
+     */
+    private DateFormat _dateFormatForWriting() {
+        return (_dateFormat == null) ? null : (DateFormat) _dateFormat.clone();
+    }
+
+    /**
+     * @return A format usable for reading textual values; falls back to a
+     *   default ISO-8601 (UTC) format when none is configured, so textual input
+     *   is always accepted.
+     */
     private DateFormat _dateFormatForReading() {
         if (_dateFormat != null) {
             return (DateFormat) _dateFormat.clone();

--- a/jr-extension-javatime/src/test/java/com/fasterxml/jackson/jr/extension/javatime/JavaUtilCalendarReadWriteTest.java
+++ b/jr-extension-javatime/src/test/java/com/fasterxml/jackson/jr/extension/javatime/JavaUtilCalendarReadWriteTest.java
@@ -1,0 +1,105 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+
+/**
+ * Tests for reading and writing {@code java.util.Calendar} from/to JSON via the
+ * Java Time extension (issue #48). Mirrors {@code java.util.Date} handling:
+ * timestamp by default, lenient reads (numeric or textual).
+ */
+public class JavaUtilCalendarReadWriteTest
+{
+    // Fixed instant: 2024-02-25T01:52:00.000Z
+    private static final long FIXED_MILLIS = 1708825920000L;
+
+    @Test
+    public void testCalendarAsTimestampRoundTrip() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final String actual = json.asString(new CalendarClass(calendarOf(FIXED_MILLIS), "A"));
+        Assertions.assertEquals("{\"aVariable\":\"A\",\"calendar\":" + FIXED_MILLIS + "}", actual);
+
+        final CalendarClass back = json.beanFrom(CalendarClass.class, actual);
+        Assertions.assertEquals(FIXED_MILLIS, back.calendar.getTimeInMillis());
+        Assertions.assertEquals("A", back.aVariable);
+    }
+
+    @Test
+    public void testCalendarAsTextualRoundTrip() throws Exception {
+        final JavaTimeReaderWriterProvider provider = new JavaTimeReaderWriterProvider()
+                .withDateFormat(utcIsoFormat());
+        final JSON json = JSON.builder()
+                .register(new JacksonJrJavaTimeExtension().with(provider))
+                .build();
+
+        final String actual = json.asString(new CalendarClass(calendarOf(FIXED_MILLIS), "A"));
+        Assertions.assertEquals("{\"aVariable\":\"A\",\"calendar\":\"2024-02-25T01:52:00.000Z\"}", actual);
+
+        final CalendarClass back = json.beanFrom(CalendarClass.class, actual);
+        Assertions.assertEquals(FIXED_MILLIS, back.calendar.getTimeInMillis());
+    }
+
+    @Test
+    public void testCalendarReadFromTextualByDefault() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final String input = "{\"aVariable\":\"X\",\"calendar\":\"2024-02-25T01:52:00.000Z\"}";
+        final CalendarClass back = json.beanFrom(CalendarClass.class, input);
+        Assertions.assertEquals(FIXED_MILLIS, back.calendar.getTimeInMillis());
+        Assertions.assertEquals("X", back.aVariable);
+    }
+
+    @Test
+    public void testCalendarReadFromTimestampWhenTextualConfigured() throws Exception {
+        final JavaTimeReaderWriterProvider provider = new JavaTimeReaderWriterProvider()
+                .withDateFormat(utcIsoFormat());
+        final JSON json = JSON.builder()
+                .register(new JacksonJrJavaTimeExtension().with(provider))
+                .build();
+
+        final String input = "{\"aVariable\":\"X\",\"calendar\":" + FIXED_MILLIS + "}";
+        final CalendarClass back = json.beanFrom(CalendarClass.class, input);
+        Assertions.assertEquals(FIXED_MILLIS, back.calendar.getTimeInMillis());
+    }
+
+    @Test
+    public void testNullCalendar() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final CalendarClass back = json.beanFrom(CalendarClass.class, "{\"aVariable\":\"X\",\"calendar\":null}");
+        Assertions.assertNull(back.calendar);
+    }
+
+    private static Calendar calendarOf(long millis) {
+        final Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        c.setTimeInMillis(millis);
+        return c;
+    }
+
+    private static DateFormat utcIsoFormat() {
+        final SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT);
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return f;
+    }
+
+    static class CalendarClass {
+        public Calendar calendar;
+        public String aVariable;
+
+        public CalendarClass() { }
+
+        public CalendarClass(Calendar calendar, String aVariable) {
+            this.calendar = calendar;
+            this.aVariable = aVariable;
+        }
+    }
+}

--- a/jr-extension-javatime/src/test/java/com/fasterxml/jackson/jr/extension/javatime/JavaUtilDateReadWriteTest.java
+++ b/jr-extension-javatime/src/test/java/com/fasterxml/jackson/jr/extension/javatime/JavaUtilDateReadWriteTest.java
@@ -1,0 +1,117 @@
+package com.fasterxml.jackson.jr.extension.javatime;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+
+/**
+ * Tests for reading and writing {@code java.util.Date} from/to JSON via the
+ * Java Time extension (issue #48). By default dates are written as numeric
+ * timestamps; reading accepts both numeric timestamps and textual values.
+ */
+public class JavaUtilDateReadWriteTest
+{
+    // Fixed instant: 2024-02-25T01:52:00.000Z
+    private static final long FIXED_MILLIS = 1708825920000L;
+
+    /**
+     * By default {@code java.util.Date} is written as a numeric timestamp and
+     * read back from it (issue #48: read what we write).
+     */
+    @Test
+    public void testDateAsTimestampRoundTrip() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final Date date = new Date(FIXED_MILLIS);
+        final String actual = json.asString(new DateClass(date, "A_VARIABLE_TEST"));
+        Assertions.assertEquals("{\"aVariable\":\"A_VARIABLE_TEST\",\"date\":" + FIXED_MILLIS + "}", actual);
+
+        final DateClass back = json.beanFrom(DateClass.class, actual);
+        Assertions.assertEquals(date, back.date);
+        Assertions.assertEquals("A_VARIABLE_TEST", back.aVariable);
+    }
+
+    /**
+     * When a {@link DateFormat} is configured, dates are written as textual
+     * values and read back using the same format.
+     */
+    @Test
+    public void testDateAsTextualRoundTrip() throws Exception {
+        final JavaTimeReaderWriterProvider provider = new JavaTimeReaderWriterProvider()
+                .withDateFormat(utcIsoFormat());
+        final JSON json = JSON.builder()
+                .register(new JacksonJrJavaTimeExtension().with(provider))
+                .build();
+
+        final Date date = new Date(FIXED_MILLIS);
+        final String actual = json.asString(new DateClass(date, "A_VARIABLE_TEST"));
+        Assertions.assertEquals("{\"aVariable\":\"A_VARIABLE_TEST\",\"date\":\"2024-02-25T01:52:00.000Z\"}", actual);
+
+        final DateClass back = json.beanFrom(DateClass.class, actual);
+        Assertions.assertEquals(date, back.date);
+    }
+
+    /**
+     * Reading is lenient: even with default (timestamp) configuration a textual
+     * value is accepted, using the default ISO-8601 format.
+     */
+    @Test
+    public void testDateReadFromTextualByDefault() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final String input = "{\"aVariable\":\"X\",\"date\":\"2024-02-25T01:52:00.000Z\"}";
+        final DateClass back = json.beanFrom(DateClass.class, input);
+        Assertions.assertEquals(new Date(FIXED_MILLIS), back.date);
+        Assertions.assertEquals("X", back.aVariable);
+    }
+
+    /**
+     * Conversely, with a textual format configured a numeric timestamp is still
+     * accepted on read.
+     */
+    @Test
+    public void testDateReadFromTimestampWhenTextualConfigured() throws Exception {
+        final JavaTimeReaderWriterProvider provider = new JavaTimeReaderWriterProvider()
+                .withDateFormat(utcIsoFormat());
+        final JSON json = JSON.builder()
+                .register(new JacksonJrJavaTimeExtension().with(provider))
+                .build();
+
+        final String input = "{\"aVariable\":\"X\",\"date\":" + FIXED_MILLIS + "}";
+        final DateClass back = json.beanFrom(DateClass.class, input);
+        Assertions.assertEquals(new Date(FIXED_MILLIS), back.date);
+    }
+
+    @Test
+    public void testNullDate() throws Exception {
+        final JSON json = JSON.builder().register(new JacksonJrJavaTimeExtension()).build();
+
+        final DateClass back = json.beanFrom(DateClass.class, "{\"aVariable\":\"X\",\"date\":null}");
+        Assertions.assertNull(back.date);
+    }
+
+    private static DateFormat utcIsoFormat() {
+        final SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT);
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return f;
+    }
+
+    static class DateClass {
+        public Date date;
+        public String aVariable;
+
+        public DateClass() { }
+
+        public DateClass(Date date, String aVariable) {
+            this.date = date;
+            this.aVariable = aVariable;
+        }
+    }
+}

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueWriterLocator.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueWriterLocator.java
@@ -318,11 +318,21 @@ public class ValueWriterLocator extends ValueLocatorBase
             if (I != null) {
                 typeId = I.intValue();
             } else {
-                typeId = _findSimpleType(type, true);
-                if ((_writerModifier != null) && typeId != 0) {
-                    ValueWriter w = _writerModifier.overrideStandardValueWriter(_writeContext, type, typeId);
-                    if (w != null) {
-                        typeId = _registerWriter(type, w);
+                // [jackson-jr#48]: consult custom provider before simple-type
+                // lookup so a `ReaderWriterProvider` can override handling of
+                // built-in types (such as `java.util.Date`) for bean properties,
+                // consistent with the reader side and top-level writer resolution.
+                ValueWriter w = (_writerProvider == null) ? null
+                        : _writerProvider.findValueWriter(_writeContext, type);
+                if (w != null) {
+                    typeId = _modifyAndRegisterWriter(type, w);
+                } else {
+                    typeId = _findSimpleType(type, true);
+                    if ((_writerModifier != null) && typeId != 0) {
+                        w = _writerModifier.overrideStandardValueWriter(_writeContext, type, typeId);
+                        if (w != null) {
+                            typeId = _registerWriter(type, w);
+                        }
                     }
                 }
                 // But what if none found? Discovered dynamically later on?


### PR DESCRIPTION
Issue: #48 
Providing Support for java.util.Date, via Extensions.