### PR TITLE
Revert #148: does not work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
     - "README.md"
     - "release-notes/*"
 permissions:
-  contents:read
+  contents: read
 
 jobs:
   build:

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanConstructors.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanConstructors.java
@@ -14,9 +14,6 @@ public class BeanConstructors
 
     protected Constructor<?> _noArgsCtor;
 
-    // @since 2.18
-    protected Constructor<?> _recordCtor;
-
     protected Constructor<?> _intCtor;
     protected Constructor<?> _longCtor;
     protected Constructor<?> _stringCtor;
@@ -27,12 +24,6 @@ public class BeanConstructors
 
     public BeanConstructors addNoArgsConstructor(Constructor<?> ctor) {
         _noArgsCtor = ctor;
-        return this;
-    }
-
-    // @since 2.18
-    public BeanConstructors addRecordConstructor(Constructor<?> ctor) {
-        _recordCtor = ctor;
         return this;
     }
 
@@ -55,9 +46,6 @@ public class BeanConstructors
         if (_noArgsCtor != null) {
             _noArgsCtor.setAccessible(true);
         }
-        if (_recordCtor != null) {
-            _recordCtor.setAccessible(true);
-        }
         if (_intCtor != null) {
             _intCtor.setAccessible(true);
         }
@@ -76,14 +64,6 @@ public class BeanConstructors
         return _noArgsCtor.newInstance((Object[]) null);
     }
 
-    // @since 2.18
-    protected Object createRecord(Object[] components) throws Exception {
-        if (_recordCtor == null) {
-            throw new IllegalStateException("Class "+_valueType.getName()+" does not have record constructor to use");
-        }
-        return _recordCtor.newInstance(components);
-    }
-    
     protected Object create(String str) throws Exception {
         if (_stringCtor == null) {
             throw new IllegalStateException("Class "+_valueType.getName()+" does not have single-String constructor to use");

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanPropertyIntrospector.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanPropertyIntrospector.java
@@ -68,8 +68,6 @@ public class BeanPropertyIntrospector
                     } else if (argType == Long.class || argType == Long.TYPE) {
                         constructors.addLongConstructor(ctor);
                     }
-                } else if (RecordsHelpers.isRecordConstructor(beanType, ctor, propsByName)) {
-                    constructors.addRecordConstructor(ctor);
                 }
             }
         }

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/BeanReader.java
@@ -36,8 +36,6 @@ public class BeanReader
      */
     protected final BeanConstructors _constructors;
 
-    protected final boolean _isRecordType;
-
     /**
      * Constructors used for deserialization use case
      *
@@ -58,7 +56,6 @@ public class BeanReader
             aliasMapping = Collections.emptyMap();
         }
         _aliasMapping = aliasMapping;
-        _isRecordType = RecordsHelpers.isRecordType(type);
     }
 
     @Deprecated // since 2.17
@@ -158,22 +155,6 @@ public class BeanReader
                 return _constructors.create(p.getLongValue());
             case START_OBJECT:
                 {
-                    // [jackson-jr#148] Record deser support (2.18)
-                    if (_isRecordType) {
-                        final List<Object> values = new ArrayList<>();
-
-                        String propName;
-                        for (; (propName = p.nextFieldName()) != null;) {
-                            BeanPropertyReader prop = findProperty(propName);
-                            if (prop == null) {
-                                handleUnknown(r, p, propName);
-                                continue;
-                            }
-                            values.add(prop.getReader().readNext(r, p));
-                        }
-                        return _constructors.createRecord(values.toArray());
-                    }
-                    // If not Record, need to use default (no-args) Constructors
                     Object bean = _constructors.create();
                     String propName;
                     final Object[] valueBuf = r._setterBuffer;

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueReaderLocator.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/ValueReaderLocator.java
@@ -473,25 +473,16 @@ public class ValueReaderLocator
                         setter = null;
                     }
                 }
-                if (RecordsHelpers.isRecordType(raw)) {
-                    try {
-                        field = raw.getDeclaredField(rawProp.name);
-                    } catch (NoSuchFieldException e) {
-                        throw new IllegalStateException("Cannot access field '" + rawProp.name
-                                + "' of record class `" + raw.getName() + "`", e);
+                // if no setter, field would do as well
+                if (setter == null) {
+                    if (field == null) {
+                        continue;
                     }
-                } else {
-                    // if no setter, field would do as well
-                    if (setter == null) {
-                        if (field == null) {
-                            continue;
-                        }
-                        // fields should always be public, but let's just double-check
-                        if (forceAccess) {
-                            field.setAccessible(true);
-                        } else if (!Modifier.isPublic(field.getModifiers())) {
-                            continue;
-                        }
+                    // fields should always be public, but let's just double-check
+                    if (forceAccess) {
+                        field.setAccessible(true);
+                    } else if (!Modifier.isPublic(field.getModifiers())) {
+                        continue;
                     }
                 }
 

--- a/jr-record-test/src/test-jdk17/java/jr/Java17RecordTest.java
+++ b/jr-record-test/src/test-jdk17/java/jr/Java17RecordTest.java
@@ -14,23 +14,9 @@ public class Java17RecordTest extends TestCase
     public record Cow(String message, Map<String, String> object) {
     }
 
-    // [jackson-jr#94]
+    // [jackson-jr#94]: Record serialization
     public void testJava14RecordSerialization() throws Exception {
-        JSON json = JSON.std;
-        var expectedDoc = "{\"message\":\"MOO\",\"object\":{\"Foo\":\"Bar\"}}";
-        Cow input = new Cow("MOO", Map.of("Foo", "Bar"));
-
-        assertEquals(expectedDoc, json.asString(input));
-    }
-
-    // [jackson-jr#148]
-    public void testJava14RecordDeserialization() throws Exception {
-        JSON json = JSON.std;
-        String inputDoc = "{\"message\":\"MOO\",\"object\":{\"Foo\":\"Bar\"}}";
-
-        Cow expected = new Cow("MOO", Map.of("Foo", "Bar"));
-
-        Cow actual = json.beanFrom(Cow.class, inputDoc);
-        assertEquals(expected, actual);
+        assertEquals("{\"message\":\"MOO\",\"object\":{\"Foo\":\"Bar\"}}",
+                JSON.std.asString(new Cow("MOO", Map.of("Foo", "Bar"))));
     }
 }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -64,8 +64,3 @@ Julian Honnen (@jhonnen)
 * Contributed fix for #90: `USE_BIG_DECIMAL_FOR_FLOATS` feature not working
   when using `JSON.treeFrom()`
  (2.17.1)
-
-Tomasz Gawęda (@TomaszGaweda)
-
-* Contributed #148: Add support for Java Record deserialization
- (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -13,8 +13,7 @@ Modules:
 
 2.18.0 (not yet released)
 
-#148: Add support for Java Record deserialization
- (contributed by Tomasz G)
+-
 
 2.17.1 (04-May-2024)
 


### PR DESCRIPTION
Unfortunately need to revert #148 (support Record deserialization): feature as implemented does not really work.

Leaving class `RecordsHelpers` as that can be useful for serialization (and future deserialization work)