### PR TITLE
Fix deserialization of snake_case fields in record classes

### DIFF
--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicAliasTest.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicAliasTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jr.annotationsupport;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.jr.ob.JSON;
 
 public class BasicAliasTest extends ASTestBase
@@ -29,6 +30,11 @@ public class BasicAliasTest extends ASTestBase
         public void setLast(String str) { last = str; }
     }
 
+    record SnakeCaseRecord(
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName
+    ) {}
+
     /*
     /**********************************************************************
     /* Test methods
@@ -55,5 +61,21 @@ public class BasicAliasTest extends ASTestBase
         assertEquals("Billy", result.first);
         assertEquals("Bob", result.middle);
         assertEquals("Burger", result.last);
+    }
+
+    public void testSnakeCaseRecordDeserialization() throws Exception
+    {
+        final String input = a2q("{ 'first_name':'John', 'last_name':'Doe' }");
+        SnakeCaseRecord result;
+
+        // First: without setting, nothing matches
+        result = JSON.std.beanFrom(SnakeCaseRecord.class, input);
+        assertNull(result.firstName());
+        assertNull(result.lastName());
+
+        // but with annotations it's all good...
+        result = JSON_WITH_ANNO.beanFrom(SnakeCaseRecord.class, input);
+        assertEquals("John", result.firstName());
+        assertEquals("Doe", result.lastName());
     }
 }

--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicIgnoralTest.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicIgnoralTest.java
@@ -43,6 +43,11 @@ public class BasicIgnoralTest extends ASTestBase
         }
     }
 
+    record SnakeCaseRecord(
+        @JsonIgnore int x,
+        @JsonProperty("y_value") int y
+    ) {}
+
     private final JSON JSON_WITH_ANNO = jsonWithAnnotationSupport();
     private final JSON JSON_WITH_ANNO_WITH_STATIC =
             JSON.builder().register(JacksonAnnotationExtension.std).enable(JSON.Feature.INCLUDE_STATIC_FIELDS).build();
@@ -109,6 +114,21 @@ public class BasicIgnoralTest extends ASTestBase
         // should read 'y', but not 'x'
         assertEquals(2, result.y);
         assertEquals(new XY().x, result.x);
+    }
+
+    public void testSnakeCaseRecordDeserialization() throws Exception
+    {
+        final String input = a2q("{ 'x':1, 'y_value':2 }");
+        SnakeCaseRecord result;
+
+        // First: without setting, nothing matches
+        result = JSON.std.beanFrom(SnakeCaseRecord.class, input);
+        assertNull(result);
+
+        // but with annotations it's all good...
+        result = JSON_WITH_ANNO.beanFrom(SnakeCaseRecord.class, input);
+        assertEquals(0, result.x());
+        assertEquals(2, result.y());
     }
 
     /*

--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicRenameTest.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicRenameTest.java
@@ -111,7 +111,10 @@ public class BasicRenameTest extends ASTestBase
         }
     }
 
-
+    record SnakeCaseRecord(
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName
+    ) {}
 
     /*
     /**********************************************************************
@@ -258,5 +261,21 @@ public class BasicRenameTest extends ASTestBase
         assertEquals("\"ENUM_NO_JSON_VALUE\"", JSON.std.asString(input));
         // with annotations
         assertEquals(a2q("\"ENUM_NO_JSON_VALUE\""), JSON_WITH_ANNO.asString(input));
+    }
+
+    public void testSnakeCaseRecordDeserialization() throws Exception
+    {
+        final String input = a2q("{ 'first_name':'John', 'last_name':'Doe' }");
+        SnakeCaseRecord result;
+
+        // First: without setting, nothing matches
+        result = JSON.std.beanFrom(SnakeCaseRecord.class, input);
+        assertNull(result.firstName());
+        assertNull(result.lastName());
+
+        // but with annotations it's all good...
+        result = JSON_WITH_ANNO.beanFrom(SnakeCaseRecord.class, input);
+        assertEquals("John", result.firstName());
+        assertEquals("Doe", result.lastName());
     }
 }

--- a/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicReorderTest.java
+++ b/jr-annotation-support/src/test/java/com/fasterxml/jackson/jr/annotationsupport/BasicReorderTest.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.jr.annotationsupport;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.jr.ob.JSON;
 
 public class BasicReorderTest extends ASTestBase
@@ -37,6 +37,11 @@ public class BasicReorderTest extends ASTestBase
         public void setLast(String n) { last = n; }
     }
 
+    record SnakeCaseRecord(
+        @JsonProperty("first_name") String firstName,
+        @JsonProperty("last_name") String lastName
+    ) {}
+
     private final JSON JSON_WITH_ANNO = jsonWithAnnotationSupport();
 
     public void testSimpleReorder() throws Exception
@@ -67,5 +72,21 @@ public class BasicReorderTest extends ASTestBase
 
         // and ensure no leakage to default one:
         assertEquals(EXP_DEFAULT, JSON.std.asString(input));
+    }
+
+    public void testSnakeCaseRecordDeserialization() throws Exception
+    {
+        final String input = a2q("{ 'first_name':'John', 'last_name':'Doe' }");
+        SnakeCaseRecord result;
+
+        // First: without setting, nothing matches
+        result = JSON.std.beanFrom(SnakeCaseRecord.class, input);
+        assertNull(result.firstName());
+        assertNull(result.lastName());
+
+        // but with annotations it's all good...
+        result = JSON_WITH_ANNO.beanFrom(SnakeCaseRecord.class, input);
+        assertEquals("John", result.firstName());
+        assertEquals("Doe", result.lastName());
     }
 }


### PR DESCRIPTION
Fix deserialization of record classes with snake_case field names annotated with `@JsonProperty`.