### PR TITLE
Fix #210: support reading `boolean[]`, `short[]`, `float[]`

### DIFF
--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
@@ -30,10 +30,13 @@ public class SimpleValueReader extends ValueReader
     private final static long[] NO_LONGS = new long[0];
 
     // @since 2.21
-    private final static double[] NO_DOUBLES = new double[0];
     private final static boolean[] NO_BOOLEANS = new boolean[0];
-    private final static short[] NO_SHORTS = new short[0];
+    // @since 2.21
+    private final static double[] NO_DOUBLES = new double[0];
+    // @since 2.21
     private final static float[] NO_FLOATS = new float[0];    
+    // @since 2.21
+    private final static short[] NO_SHORTS = new short[0];
 
     protected final int _typeId;
 
@@ -544,29 +547,29 @@ public class SimpleValueReader extends ValueReader
      * @since 2.21
      */
     private static class BooleanArrayBuilder {
-        private boolean[] buffer;
-        private int size;
+        private boolean[] _buffer;
+        private int _size;
 
         BooleanArrayBuilder() {
-            buffer = new boolean[16];
-            size = 0;
+            _buffer = new boolean[16];
+            _size = 0;
         }
 
         void add(boolean value) {
-            if (size >= buffer.length) {
-                boolean[] newBuffer = new boolean[buffer.length * 2];
-                System.arraycopy(buffer, 0, newBuffer, 0, size);
-                buffer = newBuffer;
+            if (_size >= _buffer.length) {
+                boolean[] newBuffer = new boolean[_buffer.length * 2];
+                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
+                _buffer = newBuffer;
             }
-            buffer[size++] = value;
+            _buffer[_size++] = value;
         }
 
         boolean[] toArray() {
-            if (size == buffer.length) {
-                return buffer;
+            if (_size == _buffer.length) {
+                return _buffer;
             }
-            boolean[] result = new boolean[size];
-            System.arraycopy(buffer, 0, result, 0, size);
+            boolean[] result = new boolean[_size];
+            System.arraycopy(_buffer, 0, result, 0, _size);
             return result;
         }
     }
@@ -578,29 +581,29 @@ public class SimpleValueReader extends ValueReader
      * @since 2.21
      */
     private static class ShortArrayBuilder {
-        private short[] buffer;
-        private int size;
+        private short[] _buffer;
+        private int _size;
 
         ShortArrayBuilder() {
-            buffer = new short[16];
-            size = 0;
+            _buffer = new short[16];
+            _size = 0;
         }
 
         void add(short value) {
-            if (size >= buffer.length) {
-                short[] newBuffer = new short[buffer.length * 2];
-                System.arraycopy(buffer, 0, newBuffer, 0, size);
-                buffer = newBuffer;
+            if (_size >= _buffer.length) {
+                short[] newBuffer = new short[_buffer.length * 2];
+                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
+                _buffer = newBuffer;
             }
-            buffer[size++] = value;
+            _buffer[_size++] = value;
         }
 
         short[] toArray() {
-            if (size == buffer.length) {
-                return buffer;
+            if (_size == _buffer.length) {
+                return _buffer;
             }
-            short[] result = new short[size];
-            System.arraycopy(buffer, 0, result, 0, size);
+            short[] result = new short[_size];
+            System.arraycopy(_buffer, 0, result, 0, _size);
             return result;
         }
     }
@@ -612,29 +615,29 @@ public class SimpleValueReader extends ValueReader
      * @since 2.21
      */
     private static class FloatArrayBuilder {
-        private float[] buffer;
-        private int size;
+        private float[] _buffer;
+        private int _size;
 
         FloatArrayBuilder() {
-            buffer = new float[16];
-            size = 0;
+            _buffer = new float[16];
+            _size = 0;
         }
 
         void add(float value) {
-            if (size >= buffer.length) {
-                float[] newBuffer = new float[buffer.length * 2];
-                System.arraycopy(buffer, 0, newBuffer, 0, size);
-                buffer = newBuffer;
+            if (_size >= _buffer.length) {
+                float[] newBuffer = new float[_buffer.length * 2];
+                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
+                _buffer = newBuffer;
             }
-            buffer[size++] = value;
+            _buffer[_size++] = value;
         }
 
         float[] toArray() {
-            if (size == buffer.length) {
-                return buffer;
+            if (_size == _buffer.length) {
+                return _buffer;
             }
-            float[] result = new float[size];
-            System.arraycopy(buffer, 0, result, 0, size);
+            float[] result = new float[_size];
+            System.arraycopy(_buffer, 0, result, 0, _size);
             return result;
         }
     }

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
@@ -31,11 +31,8 @@ public class SimpleValueReader extends ValueReader
 
     // @since 2.21
     private final static boolean[] NO_BOOLEANS = new boolean[0];
-    // @since 2.21
     private final static double[] NO_DOUBLES = new double[0];
-    // @since 2.21
-    private final static float[] NO_FLOATS = new float[0];    
-    // @since 2.21
+    private final static float[] NO_FLOATS = new float[0];
     private final static short[] NO_SHORTS = new short[0];
 
     protected final int _typeId;
@@ -566,9 +563,7 @@ public class SimpleValueReader extends ValueReader
             if (_size == _buffer.length) {
                 return _buffer;
             }
-            boolean[] result = new boolean[_size];
-            System.arraycopy(_buffer, 0, result, 0, _size);
-            return result;
+            return Arrays.copyOf(_buffer, _size);
         }
     }
 
@@ -598,9 +593,7 @@ public class SimpleValueReader extends ValueReader
             if (_size == _buffer.length) {
                 return _buffer;
             }
-            short[] result = new short[_size];
-            System.arraycopy(_buffer, 0, result, 0, _size);
-            return result;
+            return Arrays.copyOf(_buffer, _size);
         }
     }
 
@@ -630,9 +623,7 @@ public class SimpleValueReader extends ValueReader
             if (_size == _buffer.length) {
                 return _buffer;
             }
-            float[] result = new float[_size];
-            System.arraycopy(_buffer, 0, result, 0, _size);
-            return result;
+            return Arrays.copyOf(_buffer, _size);
         }
     }
 }

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
@@ -30,7 +30,10 @@ public class SimpleValueReader extends ValueReader
     private final static long[] NO_LONGS = new long[0];
 
     // @since 2.21
-    private final static double[] NO_DOUBLES = new double[0];    
+    private final static double[] NO_DOUBLES = new double[0];
+    private final static boolean[] NO_BOOLEANS = new boolean[0];
+    private final static short[] NO_SHORTS = new short[0];
+    private final static float[] NO_FLOATS = new float[0];    
 
     protected final int _typeId;
 
@@ -116,13 +119,12 @@ public class SimpleValueReader extends ValueReader
             return _readIntArray(p);
         case SER_LONG_ARRAY:
             return _readLongArray(p);
- 
-        // Not yet supported:
         case SER_BOOLEAN_ARRAY:
+            return _readBooleanArray(p);
         case SER_SHORT_ARRAY:
+            return _readShortArray(p);
         case SER_FLOAT_ARRAY:
-            throw JSONObjectException.from(p,
-                "Deserialization of `"+_valueTypeDesc()+"` not yet supported");
+            return _readFloatArray(p);
         case SER_DOUBLE_ARRAY:
             return _readDoubleArray(p);
 
@@ -425,5 +427,215 @@ public class SimpleValueReader extends ValueReader
             t = p.currentTokenId();
         }
         return builder.build().toArray();
+    }
+
+    // @since 2.21
+    protected boolean[] _readBooleanArray(JsonParser p) throws IOException {
+        if (JsonToken.START_ARRAY.equals(p.currentToken())) {
+            p.nextToken();
+        }
+
+        int t = p.currentTokenId();
+
+        if (t == JsonTokenId.ID_END_ARRAY) {
+            return NO_BOOLEANS;
+        }
+
+        final BooleanArrayBuilder builder = new BooleanArrayBuilder();
+
+        main_loop:
+        while (true) {
+            switch (t) {
+            case JsonTokenId.ID_TRUE:
+            case JsonTokenId.ID_FALSE:
+            case JsonTokenId.ID_NULL:
+                builder.add(p.getValueAsBoolean());
+                break;
+            case JsonTokenId.ID_END_ARRAY:
+                break main_loop;
+            default:
+                throw new JSONObjectException("Failed to bind `boolean` element of `boolean[]` from value: "+
+                        _tokenDesc(p));
+            }
+            p.nextToken();
+            t = p.currentTokenId();
+        }
+        return builder.toArray();
+    }
+
+    // @since 2.21
+    protected short[] _readShortArray(JsonParser p) throws IOException {
+        if (JsonToken.START_ARRAY.equals(p.currentToken())) {
+            p.nextToken();
+        }
+
+        int t = p.currentTokenId();
+
+        if (t == JsonTokenId.ID_END_ARRAY) {
+            return NO_SHORTS;
+        }
+
+        final ShortArrayBuilder builder = new ShortArrayBuilder();
+
+        main_loop:
+        while (true) {
+            switch (t) {
+            case JsonTokenId.ID_NUMBER_FLOAT:
+            case JsonTokenId.ID_NUMBER_INT:
+            case JsonTokenId.ID_NULL:
+                builder.add((short) p.getValueAsInt());
+                break;
+            case JsonTokenId.ID_END_ARRAY:
+                break main_loop;
+            default:
+                throw new JSONObjectException("Failed to bind `short` element of `short[]` from value: "+
+                        _tokenDesc(p));
+            }
+            p.nextToken();
+            t = p.currentTokenId();
+        }
+        return builder.toArray();
+    }
+
+    // @since 2.21
+    protected float[] _readFloatArray(JsonParser p) throws IOException {
+        if (JsonToken.START_ARRAY.equals(p.currentToken())) {
+            p.nextToken();
+        }
+
+        int t = p.currentTokenId();
+
+        if (t == JsonTokenId.ID_END_ARRAY) {
+            return NO_FLOATS;
+        }
+
+        final FloatArrayBuilder builder = new FloatArrayBuilder();
+
+        main_loop:
+        while (true) {
+            switch (t) {
+            case JsonTokenId.ID_NUMBER_FLOAT:
+            case JsonTokenId.ID_NUMBER_INT:
+            case JsonTokenId.ID_NULL:
+                builder.add((float) p.getValueAsDouble());
+                break;
+            case JsonTokenId.ID_END_ARRAY:
+                break main_loop;
+            default:
+                throw new JSONObjectException("Failed to bind `float` element of `float[]` from value: "+
+                        _tokenDesc(p));
+            }
+            p.nextToken();
+            t = p.currentTokenId();
+        }
+        return builder.toArray();
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper classes for primitive array building
+    /**********************************************************************
+     */
+
+    /**
+     * Simple builder for boolean arrays, similar to IntStream.Builder
+     * but optimized for our specific use case.
+     *
+     * @since 2.21
+     */
+    private static class BooleanArrayBuilder {
+        private boolean[] buffer;
+        private int size;
+
+        BooleanArrayBuilder() {
+            buffer = new boolean[16];
+            size = 0;
+        }
+
+        void add(boolean value) {
+            if (size >= buffer.length) {
+                boolean[] newBuffer = new boolean[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuffer, 0, size);
+                buffer = newBuffer;
+            }
+            buffer[size++] = value;
+        }
+
+        boolean[] toArray() {
+            if (size == buffer.length) {
+                return buffer;
+            }
+            boolean[] result = new boolean[size];
+            System.arraycopy(buffer, 0, result, 0, size);
+            return result;
+        }
+    }
+
+    /**
+     * Simple builder for short arrays, similar to IntStream.Builder
+     * but optimized for our specific use case.
+     *
+     * @since 2.21
+     */
+    private static class ShortArrayBuilder {
+        private short[] buffer;
+        private int size;
+
+        ShortArrayBuilder() {
+            buffer = new short[16];
+            size = 0;
+        }
+
+        void add(short value) {
+            if (size >= buffer.length) {
+                short[] newBuffer = new short[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuffer, 0, size);
+                buffer = newBuffer;
+            }
+            buffer[size++] = value;
+        }
+
+        short[] toArray() {
+            if (size == buffer.length) {
+                return buffer;
+            }
+            short[] result = new short[size];
+            System.arraycopy(buffer, 0, result, 0, size);
+            return result;
+        }
+    }
+
+    /**
+     * Simple builder for float arrays, similar to DoubleStream.Builder
+     * but optimized for our specific use case.
+     *
+     * @since 2.21
+     */
+    private static class FloatArrayBuilder {
+        private float[] buffer;
+        private int size;
+
+        FloatArrayBuilder() {
+            buffer = new float[16];
+            size = 0;
+        }
+
+        void add(float value) {
+            if (size >= buffer.length) {
+                float[] newBuffer = new float[buffer.length * 2];
+                System.arraycopy(buffer, 0, newBuffer, 0, size);
+                buffer = newBuffer;
+            }
+            buffer[size++] = value;
+        }
+
+        float[] toArray() {
+            if (size == buffer.length) {
+                return buffer;
+            }
+            float[] result = new float[size];
+            System.arraycopy(buffer, 0, result, 0, size);
+            return result;
+        }
     }
 }

--- a/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
+++ b/jr-objects/src/main/java/com/fasterxml/jackson/jr/ob/impl/SimpleValueReader.java
@@ -557,9 +557,7 @@ public class SimpleValueReader extends ValueReader
 
         void add(boolean value) {
             if (_size >= _buffer.length) {
-                boolean[] newBuffer = new boolean[_buffer.length * 2];
-                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
-                _buffer = newBuffer;
+                _buffer = Arrays.copyOf(_buffer, _buffer.length * 2);
             }
             _buffer[_size++] = value;
         }
@@ -591,9 +589,7 @@ public class SimpleValueReader extends ValueReader
 
         void add(short value) {
             if (_size >= _buffer.length) {
-                short[] newBuffer = new short[_buffer.length * 2];
-                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
-                _buffer = newBuffer;
+                _buffer = Arrays.copyOf(_buffer, _buffer.length * 2);
             }
             _buffer[_size++] = value;
         }
@@ -625,9 +621,7 @@ public class SimpleValueReader extends ValueReader
 
         void add(float value) {
             if (_size >= _buffer.length) {
-                float[] newBuffer = new float[_buffer.length * 2];
-                System.arraycopy(_buffer, 0, newBuffer, 0, _size);
-                _buffer = newBuffer;
+                _buffer = Arrays.copyOf(_buffer, _buffer.length * 2);
             }
             _buffer[_size++] = value;
         }

--- a/jr-objects/src/test/java/com/fasterxml/jackson/jr/ob/PrimitiveArrayTest.java
+++ b/jr-objects/src/test/java/com/fasterxml/jackson/jr/ob/PrimitiveArrayTest.java
@@ -28,8 +28,6 @@ public class PrimitiveArrayTest extends TestBase
     private final static String BOOLEAN_ARRAY_JSON = "[true,false,true,false,true]";
     private final static boolean[] BOOLEAN_ARRAY = new boolean[] { true, false, true, false, true };
 
-    // Not yet implemented in Jackson-jr
-    @JacksonTestFailureExpected
     @Test
     public void testBooleanArrayRead() throws Exception {
         assertArrayEquals(BOOLEAN_ARRAY, JSON.std.beanFrom(boolean[].class, BOOLEAN_ARRAY_JSON));
@@ -71,16 +69,9 @@ public class PrimitiveArrayTest extends TestBase
     private final static String SHORT_ARRAY_JSON = "[1,2,3,32767,-32768]";
     private final static short[] SHORT_ARRAY = new short[] { 1, 2, 3, 32767, -32768 };
 
-    // Not yet implemented in Jackson-jr
     @Test
     public void testShortArrayRead() throws Exception {
-//        assertArrayEquals(SHORT_ARRAY, JSON.std.beanFrom(short[].class, SHORT_ARRAY_JSON));
-        try {
-            JSON.std.beanFrom(short[].class, SHORT_ARRAY_JSON);
-            fail("Should not pass");
-        } catch (JSONObjectException e) {
-            verifyException(e, "Deserialization of `short[]` not yet supported");
-        }
+        assertArrayEquals(SHORT_ARRAY, JSON.std.beanFrom(short[].class, SHORT_ARRAY_JSON));
     }
 
     @Test
@@ -117,18 +108,10 @@ public class PrimitiveArrayTest extends TestBase
     private final static String FLOAT_ARRAY_JSON = "[1.0,2.5,3.125,-5.5,0.0]";
     private final static float[] FLOAT_ARRAY = new float[] {1.0f, 2.5f, 3.125f, -5.5f, 0.0f};
 
-    // Not yet implemented in Jackson-jr
     @Test
     public void testFloatArrayRead() throws Exception {
-        //assertArrayEquals(FLOAT_ARRAY, JSON.std.beanFrom(float[].class, FLOAT_ARRAY_JSON),
-        //        0.00001f);
-
-        try {
-            JSON.std.beanFrom(float[].class, FLOAT_ARRAY_JSON);
-            fail("Should not pass");
-        } catch (JSONObjectException e) {
-            verifyException(e, "Deserialization of `float[]` not yet supported");
-        }
+        assertArrayEquals(FLOAT_ARRAY, JSON.std.beanFrom(float[].class, FLOAT_ARRAY_JSON),
+                0.00001f);
     }
 
     @Test
@@ -159,33 +142,33 @@ public class PrimitiveArrayTest extends TestBase
         assertArrayEquals(new double[0], JSON.std.beanFrom(double[].class, "[]"), 0.0);
     }
 
-    // Empty arrays: Not yet implemented in Jackson-jr
-    @JacksonTestFailureExpected
     @Test
-    public void testEmptyArraysFailingBooleanArray() throws Exception {
+    public void testEmptyBooleanArray() throws Exception {
         assertArrayEquals(new boolean[0], JSON.std.beanFrom(boolean[].class, "[]"));
     }
 
-    @JacksonTestFailureExpected
+    // byte[] still uses Base64 encoding, not JSON array
     @Test
-    public void testEmptyArraysFailingByteArray() throws Exception {
-        assertArrayEquals(new byte[0], JSON.std.beanFrom(byte[].class, "[]"));
+    public void testEmptyByteArrayStillUsesBase64() throws Exception {
+        // byte[] is special - it doesn't read from JSON arrays
+        try {
+            JSON.std.beanFrom(byte[].class, "[]");
+            fail("Should not pass");
+        } catch (JSONObjectException e) {
+            verifyException(e, "Can only bind `byte[]` from Binary value");
+        }
     }
 
-    @JacksonTestFailureExpected
     @Test
-    public void testEmptyArraysFailingShortArray() throws Exception {
+    public void testEmptyShortArray() throws Exception {
         assertArrayEquals(new short[0], JSON.std.beanFrom(short[].class, "[]"));
     }
 
-    @JacksonTestFailureExpected
     @Test
-    public void testEmptyArraysFailingFloatArray() throws Exception {
+    public void testEmptyFloatArray() throws Exception {
         assertArrayEquals(new float[0], JSON.std.beanFrom(float[].class, "[]"), 0.0f);
     }
 
-    // Not yet fully implemented in Jackson-jr
-    @JacksonTestFailureExpected
     @Test
     public void testArraysAsObjectFields() throws Exception {
         AllArraysBean input = new AllArraysBean();

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,8 @@ Modules:
  (reported by Juul H)
  (fix contributed by Tomasz G)
 #208: Support reading of `double[]`
+#210: Support reading `boolean[]`/`short[]`/`float[]` values
+ (fix by @cowtowncoder, w/ Claude code)
 
 2.20.0 (28-Aug-2025)
 


### PR DESCRIPTION
  Implements deserialization support for three additional primitive array types:

  - `boolean[]`
  - `short[]`
  - `float[]`

  This completes primitive array support in jackson-jr alongside existing `int[]`, `long[]`, `double[]`
   support (and `byte[]`, `char[]` which behave bit differently)

  Fixes #210
